### PR TITLE
Prevent errors for unavailable sensors on HA start

### DIFF
--- a/custom_components/thermal_comfort/sensor.py
+++ b/custom_components/thermal_comfort/sensor.py
@@ -10,7 +10,7 @@ from homeassistant.const import (
     ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT, CONF_ICON_TEMPLATE,
 	CONF_ENTITY_PICTURE_TEMPLATE, CONF_SENSORS, EVENT_HOMEASSISTANT_START,
 	MATCH_ALL, CONF_DEVICE_CLASS, DEVICE_CLASS_TEMPERATURE, STATE_UNKNOWN,
-        DEVICE_CLASS_HUMIDITY, ATTR_TEMPERATURE)
+        STATE_UNAVAILABLE, DEVICE_CLASS_HUMIDITY, ATTR_TEMPERATURE)
 from homeassistant.exceptions import TemplateError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity, async_generate_entity_id
@@ -105,23 +105,23 @@ class SensorThermalComfort(Entity):
             self.hass, self._humidity_entity, self.humidity_state_listener)
 
         temperature_state = hass.states.get(temperature_entity)
-        if temperature_state and temperature_state.state != STATE_UNKNOWN:
+        if temperature_state and temperature_state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
             self._temperature = float(temperature_state.state)
 
         humidity_state = hass.states.get(humidity_entity)
-        if humidity_state and humidity_state.state != STATE_UNKNOWN:
+        if humidity_state and humidity_state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
             self._humidity = float(humidity_state.state)
 
     def temperature_state_listener(self, entity, old_state, new_state):
         """Handle temperature device state changes."""
-        if new_state and new_state.state != STATE_UNKNOWN:
+        if new_state and new_state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
             self._temperature = float(new_state.state)
 
         self.async_schedule_update_ha_state(True)
 
     def humidity_state_listener(self, entity, old_state, new_state):
         """Handle humidity device state changes."""
-        if new_state and new_state.state != STATE_UNKNOWN:
+        if new_state and new_state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
             self._humidity = float(new_state.state)
 
         self.async_schedule_update_ha_state(True)


### PR DESCRIPTION
2019-06-26 12:12:44 ERROR (MainThread) [homeassistant.core] Error doing job: Future exception was never retrieved Traceback (most recent call last): File "/usr/lib/python3.7/concurrent/futures/thread.py", line 57, in run result = self.fn(*self.args, **self.kwargs) File "/home/homeassi/.homeassistant/custom_components/thermal_comfort/sensor.py", line 118, in temperature_state_listener self._temperature = float(new_state.state) ValueError: could not convert string to float: 'unavailable'