### PR TITLE
Add HACS custom support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # thermal_comfort
 Thermal Comfort sensor for HA (absolute humidity, heat index, dew point, thermal perception)
 
+[![hacs_badge](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://github.com/hacs/integration)
+
 ## Usage
 
 To use, add the following to your `configuration.yaml` file:

--- a/custom_components/thermal_comfort/manifest.json
+++ b/custom_components/thermal_comfort/manifest.json
@@ -3,6 +3,7 @@
   "name": "Thermal Comfort",
   "version": "2021.3.1",
   "documentation": "https://github.com/dolezsa/thermal_comfort/blob/master/README.md",
+  "issue_tracker": "https://github.com/dolezsa/thermal_comfort/issues",
   "dependencies": [],
   "codeowners": ["@dolezsa"],
   "requirements": []

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,4 @@
+{
+  "name": "Thermal Comfort",
+  "render_readme": true
+}


### PR DESCRIPTION
Add hacs.json, issue_tracker attribute to manifest.json and a badge that
should help make it clear that this needs to be added as a custom
repository to be used in hacs (Partially addressing #18).