### PR TITLE
sensor: implement unique_id for yaml config

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ sensor:
 - friendly_name
 - icon_template
 - entity_picture_template
+- unique_id
 
 ## Screenshots
 


### PR DESCRIPTION
This adds the optional configuration variable unique_id to the sensor
platform. This allows the user to set a unique_id per sensor, the
sensor_type of each entity is added to make it unique per entity.

If this is set, it allows to partially manage the entities from the UI
without enabling the advanced mode. Specifically, this allows to use the
Area setting, which is used in the default Lovelace Dashboard.

Note: This also includes a small reformatting change, there was mixed intent in line 12-13, those had tabs, i replaced them with spaces to match the rest of the file.