### PR TITLE
sensor: fix check for None on async_update

### DIFF
--- a/custom_components/thermal_comfort/sensor.py
+++ b/custom_components/thermal_comfort/sensor.py
@@ -261,7 +261,7 @@ class SensorThermalComfort(Entity):
     async def async_update(self):
         """Update the state."""
         value = None
-        if self._temperature and self._humidity:
+        if self._temperature is not None and self._humidity is not None:
             if self._sensor_type == "dewpoint":
                 value = self.computeDewPoint(self._temperature, self._humidity)
             if self._sensor_type == "heatindex":


### PR DESCRIPTION
Check for None instead of just the boolean value of self._temperature
and self._humidity since bool(0.0) == False, which is not intended.
Fixes #24