### PR TITLE
Sensor types

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ sensor:
         friendly_name: Living Room
         temperature_sensor: sensor.temperature_livingroom
         humidity_sensor: sensor.humidity_livingroom
+      bathroom:
+        temperature_sensor: sensor.temperature_bathroom
+        humidity_sensor: sensor.humidity_bathroom
+        sensor_types:
+          - absolutehumidity
+          - heatindex
       bedroom:
         ...
 
@@ -29,6 +35,11 @@ sensor:
 - icon_template
 - entity_picture_template
 - unique_id
+- sensor_types
+
+`sensor_types` is a list of sensors that must be created.
+It can be any of: "absolutehumidity", "heatindex", "dewpoint", "perception".
+If not provided, all sensors will be created.
 
 ## Screenshots
 

--- a/custom_components/thermal_comfort/sensor.py
+++ b/custom_components/thermal_comfort/sensor.py
@@ -26,11 +26,15 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_TEMPERATURE_SENSOR = 'temperature_sensor'
 CONF_HUMIDITY_SENSOR = 'humidity_sensor'
+CONF_SENSOR_TYPES = 'sensor_types'
 ATTR_HUMIDITY = 'humidity'
+
+DEFAULT_SENSOR_TYPES = ["absolutehumidity", "heatindex", "dewpoint", "perception"]
 
 SENSOR_SCHEMA = vol.Schema({
     vol.Required(CONF_TEMPERATURE_SENSOR): cv.entity_id,
     vol.Required(CONF_HUMIDITY_SENSOR): cv.entity_id,
+    vol.Optional(CONF_SENSOR_TYPES, default=DEFAULT_SENSOR_TYPES): cv.ensure_list,
     vol.Optional(CONF_ICON_TEMPLATE): cv.template,
     vol.Optional(CONF_ENTITY_PICTURE_TEMPLATE): cv.template,
     vol.Optional(ATTR_FRIENDLY_NAME): cv.string,
@@ -65,12 +69,14 @@ async def async_setup_platform(hass, config, async_add_entities,
     for device, device_config in config[CONF_SENSORS].items():
         temperature_entity = device_config.get(CONF_TEMPERATURE_SENSOR)
         humidity_entity = device_config.get(CONF_HUMIDITY_SENSOR)
+        config_sensor_types = device_config.get(CONF_SENSOR_TYPES)
         icon_template = device_config.get(CONF_ICON_TEMPLATE)
         entity_picture_template = device_config.get(CONF_ENTITY_PICTURE_TEMPLATE)
         friendly_name = device_config.get(ATTR_FRIENDLY_NAME, device)
         unique_id = device_config.get(CONF_UNIQUE_ID)
 
         for sensor_type in SENSOR_TYPES:
+            if sensor_type in config_sensor_types :
                 sensors.append(
                         SensorThermalComfort(
                                 hass,

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -258,3 +258,44 @@ async def test_zero_degree_celcius(hass, start_ha):
     await hass.async_block_till_done()
     assert hass.states.get(f"{TEST_NAME}_dewpoint") is not None
     assert hass.states.get(f"{TEST_NAME}_dewpoint").state == "-9.19"
+
+
+@pytest.mark.parametrize("domains", [({
+    sensor.DOMAIN: {
+        "count": 3,
+        "config": {
+            "sensor": [
+                {
+                    "platform": 'command_line',
+                    "command": 'echo 0',
+                    "name": "test_temperature_sensor",
+                    "value_template": "{{ 25.0 | float }}",
+                },
+                {
+                    "platform": 'command_line',
+                    "command": 'echo 0',
+                    "name": "test_humidity_sensor",
+                    "value_template": "{{ 50.0 | float }}",
+                },
+                {
+                    "platform": "thermal_comfort",
+                    "sensors": {
+                        "test_thermal_comfort": {
+                            "temperature_sensor": "sensor.test_temperature_sensor",
+                            "humidity_sensor": "sensor.test_humidity_sensor",
+                            "sensor_types": ["absolutehumidity", "dewpoint"],
+                        },
+                    },
+                },
+            ],
+        },
+    },
+})])
+async def test_sensor_types(hass, start_ha):
+    assert len(hass.states.async_all("sensor")) == 4
+
+    assert hass.states.get(f"{TEST_NAME}_heatindex") is None
+    assert hass.states.get(f"{TEST_NAME}_perception") is None
+
+    assert hass.states.get(f"{TEST_NAME}_absolutehumidity") is not None
+    assert hass.states.get(f"{TEST_NAME}_dewpoint") is not None


### PR DESCRIPTION
Cherry pick 0717395dc9e9c41c09abedf88876359ed7a1b045 to add support for sensor_types config which allows to create only some sensors. Add corresponding test case.
Fixes #7 