### PR TITLE
Fix check for float in tuple

### DIFF
--- a/custom_components/thermal_comfort/sensor.py
+++ b/custom_components/thermal_comfort/sensor.py
@@ -279,4 +279,10 @@ class SensorThermalComfort(Entity):
 
 
 def _is_valid_state(state) -> bool:
-    return state and state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE, math.isnan(float(state.state)))
+    if state is not None:
+        if state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+            try:
+                return not math.isnan(float(state.state))
+            except:
+                pass
+    return False


### PR DESCRIPTION
Don't check for both strings and floats in a tuple. Make _is_valid_state
more expressive and add corresponding tests.

Fixes #37