### PR TITLE
Add frost point and frost risk sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Thermal Comfort provides the following calculated sensors for Home Assistant:
  * Heat Index `heatindex`
  * Dew Point `dewpoint`
  * Thermal Perception `perception`
+ * Frost point `frostpoint`
+ * Frost Risk `frostrisk`
 
 ## Usage
 
@@ -44,7 +46,7 @@ sensor:
   <dt><strong>unique_id</strong> <code>string</code> <code>(optional)</code></dt>
   <dd>An ID that uniquely identifies the sensors. Set this to a unique value to allow customization through the UI.</dd>
   <dt><strong>sensor_types</strong> <code>list</code> <code>(optional)</code></dt>
-  <dd>A list of sensors to create. If omitted all will be created. Available sensors: <code>absolutehumidity</code>, <code>heatindex</code>, <code>dewpoint</code>, <code>perception</code></dd>
+  <dd>A list of sensors to create. If omitted all will be created. Available sensors: <code>absolutehumidity</code>, <code>heatindex</code>, <code>dewpoint</code>, <code>perception</code>, <code>frostpoint</code>, <code>frostrisk</code></dd>
 </dl>
 
 ## Installation

--- a/custom_components/thermal_comfort/translations/sensor.de.json
+++ b/custom_components/thermal_comfort/translations/sensor.de.json
@@ -1,5 +1,11 @@
 {
   "state": {
+    "thermal_comfort__frost_risk": {
+      "no_risk": "Kein Risiko",
+      "unlikely": "Unwahrscheinlich",
+      "probable": "Wahrscheinlich",
+      "high": "Sehr wahrscheinlich"
+    },
     "thermal_comfort__thermal_perception": {
       "dry": "Etwas trocken",
       "very_comfortable": "Sehr angenehm",

--- a/custom_components/thermal_comfort/translations/sensor.en.json
+++ b/custom_components/thermal_comfort/translations/sensor.en.json
@@ -1,5 +1,11 @@
 {
   "state": {
+    "thermal_comfort__frost_risk": {
+      "no_risk": "No risk",
+      "unlikely": "Unlikely",
+      "probable": "Probable",
+      "high": "High probability"
+    },
     "thermal_comfort__thermal_perception": {
       "dry": "A bit dry for some",
       "very_comfortable": "Very comfortable",

--- a/custom_components/thermal_comfort/translations/sensor.fr.json
+++ b/custom_components/thermal_comfort/translations/sensor.fr.json
@@ -1,5 +1,11 @@
 {
   "state": {
+    "thermal_comfort__frost_risk": {
+      "no_risk": "Aucun risque",
+      "unlikely": "Peu probable",
+      "probable": "Probable",
+      "high": "Haute probabilité"
+    },
     "thermal_comfort__thermal_perception": {
       "dry": "Un peu sec pour certains",
       "very_comfortable": "Très confortable",

--- a/custom_components/thermal_comfort/translations/sensor.it.json
+++ b/custom_components/thermal_comfort/translations/sensor.it.json
@@ -1,5 +1,11 @@
 {
   "state": {
+    "thermal_comfort__frost_risk": {
+      "no_risk": "Nessun rischio",
+      "unlikely": "Improbabile",
+      "probable": "Probabile",
+      "high": "Alta probabilità"
+    },
     "thermal_comfort__thermal_perception": {
       "dry": "Un po' secco per alcuni",
       "very_comfortable": "Molto confortabile",


### PR DESCRIPTION
This adds both a frost point and a frost risk sensor as default sensors
to the sensor platform. Both are based on @papo-o's functions, which
where provided by them. See also his fork of thermal comfort for this
sensors https://github.com/papo-o/home-assistant-frost-risks.

See #36 

Currently this adds the two new sensors as default because the expected behavior for 1.0.0 is to add all sensors if this config variable is not explicitly set. So it may be confusing for users if we just derivative from that behavior now.