### PR TITLE
Add frost point and frost risk sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Thermal Comfort provides the following calculated sensors for Home Assistant:
  * Heat Index `heatindex`
  * Dew Point `dewpoint`
  * Thermal Perception `perception`
+ * Frost point `frostpoint`
+ * Frost Risk `frostrisk`
 
 ## Usage
 
@@ -44,7 +46,7 @@ sensor:
   <dt><strong>unique_id</strong> <code>string</code> <code>(optional)</code></dt>
   <dd>An ID that uniquely identifies the sensors. Set this to a unique value to allow customization through the UI.</dd>
   <dt><strong>sensor_types</strong> <code>list</code> <code>(optional)</code></dt>
-  <dd>A list of sensors to create. If omitted all will be created. Available sensors: <code>absolutehumidity</code>, <code>heatindex</code>, <code>dewpoint</code>, <code>perception</code></dd>
+  <dd>A list of sensors to create. If omitted all will be created. Available sensors: <code>absolutehumidity</code>, <code>heatindex</code>, <code>dewpoint</code>, <code>perception</code>, <code>frostpoint</code>, <code>frostrisk</code></dd>
 </dl>
 
 ## Installation

--- a/custom_components/thermal_comfort/sensor.py
+++ b/custom_components/thermal_comfort/sensor.py
@@ -28,9 +28,20 @@ CONF_TEMPERATURE_SENSOR = 'temperature_sensor'
 CONF_HUMIDITY_SENSOR = 'humidity_sensor'
 CONF_SENSOR_TYPES = 'sensor_types'
 ATTR_HUMIDITY = 'humidity'
+ATTR_FROST_RISK_LEVEL = 'frost_risk_level'
 DEVICE_CLASS_THERMAL_PERCEPTION ='thermal_comfort__thermal_perception'
+DEVICE_CLASS_FROST_RISK = 'thermal_comfort__frost_risk'
 
-DEFAULT_SENSOR_TYPES = ["absolutehumidity", "heatindex", "dewpoint", "perception"]
+SENSOR_TYPES = {
+    'absolutehumidity': [DEVICE_CLASS_HUMIDITY, 'Absolute Humidity', 'g/m³'],
+    'heatindex': [DEVICE_CLASS_TEMPERATURE, 'Heat Index', '°C'],
+    'dewpoint': [DEVICE_CLASS_TEMPERATURE, 'Dew Point', '°C'],
+    'perception': [DEVICE_CLASS_THERMAL_PERCEPTION, 'Thermal Perception', None],
+    'frostpoint': [DEVICE_CLASS_TEMPERATURE, 'Frost Point', '°C'],
+    'frostrisk': [DEVICE_CLASS_FROST_RISK, 'Frost Risk', None],
+}
+
+DEFAULT_SENSOR_TYPES = list(SENSOR_TYPES.keys())
 
 SENSOR_SCHEMA = vol.Schema({
     vol.Required(CONF_TEMPERATURE_SENSOR): cv.entity_id,
@@ -46,12 +57,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_SENSORS): cv.schema_with_slug_keys(SENSOR_SCHEMA),
 })
 
-SENSOR_TYPES = {
-    'absolutehumidity': [DEVICE_CLASS_HUMIDITY, 'Absolute Humidity', 'g/m³'],
-    'heatindex': [DEVICE_CLASS_TEMPERATURE, 'Heat Index', '°C'],
-    'dewpoint': [DEVICE_CLASS_TEMPERATURE, 'Dew Point', '°C'],
-    'perception': [DEVICE_CLASS_THERMAL_PERCEPTION, 'Thermal Perception', None],
-}
 
 PERCEPTION_DRY = "dry"
 PERCEPTION_VERY_COMFORTABLE = "very_comfortable"
@@ -61,6 +66,13 @@ PERCEPTION_SOMEWHAT_UNCOMFORTABLE = "somewhat_uncomfortable"
 PERCEPTION_QUITE_UNCOMFORTABLE = "quite_uncomfortable"
 PERCEPTION_EXTREMELY_UNCOMFORTABLE = "extremely_uncomfortable"
 PERCEPTION_SEVERELY_HIGH = "severely_high"
+
+FROST_RISK = [
+        "no_risk",
+        "unlikely",
+        "probable",
+        "high",
+]
 
 async def async_setup_platform(hass, config, async_add_entities,
                                discovery_info=None):
@@ -227,6 +239,27 @@ class SensorThermalComfort(Entity):
         absHumidity /= absTemperature;
         return round(absHumidity, 2)
 
+    def computeFrostPoint(self, temperature, humidity):
+        """ https://pon.fr/dzvents-alerte-givre-et-calcul-humidite-absolue/ """
+        dewPoint = self.computeDewPoint(temperature, humidity)
+        T = temperature + 273.15
+        Td = dewPoint + 273.15
+        return round((Td + (2671.02 /((2954.61/T) + 2.193665 * math.log(T) - 13.3448))-T)-273.15,2)
+
+    def computeRiskLevel(self, temperature, humidity):
+        thresholdAbsHumidity = 2.8
+        dewPoint = self.computeDewPoint(temperature, humidity)
+        absoluteHumidity = self.computeAbsoluteHumidity(temperature, humidity)
+        freezePoint = self.computeFrostPoint(temperature, humidity)
+        if temperature <= 1 and freezePoint <= 0:
+            if absoluteHumidity <= thresholdAbsHumidity:
+                return 1 # Frost unlikely despite the temperature
+            else:
+                return 3 # high probability of frost
+        elif temperature <= 4 and freezePoint <= 0.5 and absoluteHumidity > thresholdAbsHumidity:
+            return 2 # Frost probable despite the temperature
+        return 0 # No risk of frost
+
     async def async_added_to_hass(self):
         async_track_state_change_event(
             self.hass, self._temperature_entity, self.temperature_state_listener)
@@ -246,8 +279,12 @@ class SensorThermalComfort(Entity):
                 value = self.computePerception(self._temperature, self._humidity)
             elif self._sensor_type == "absolutehumidity":
                 value = self.computeAbsoluteHumidity(self._temperature, self._humidity)
-            elif self._sensor_type == "comfortratio":
-                value = "comfortratio"
+            elif self._sensor_type == "frostpoint":
+                value = self.computeFrostPoint(self._temperature, self._humidity)
+            elif self._sensor_type == "frostrisk":
+                risk_level = self.computeRiskLevel(self._temperature, self._humidity)
+                value = FROST_RISK[risk_level]
+                self._attr_extra_state_attributes[ATTR_FROST_RISK_LEVEL] = risk_level
 
         self._attr_state = value
         self._attr_extra_state_attributes[ATTR_TEMPERATURE] = self._temperature

--- a/custom_components/thermal_comfort/translations/sensor.de.json
+++ b/custom_components/thermal_comfort/translations/sensor.de.json
@@ -1,5 +1,11 @@
 {
   "state": {
+    "thermal_comfort__frost_risk": {
+      "no_risk": "Kein Risiko",
+      "unlikely": "Unwahrscheinlich",
+      "probable": "Wahrscheinlich",
+      "high": "Sehr wahrscheinlich"
+    },
     "thermal_comfort__thermal_perception": {
       "dry": "Etwas trocken",
       "very_comfortable": "Sehr angenehm",

--- a/custom_components/thermal_comfort/translations/sensor.en.json
+++ b/custom_components/thermal_comfort/translations/sensor.en.json
@@ -1,5 +1,11 @@
 {
   "state": {
+    "thermal_comfort__frost_risk": {
+      "no_risk": "No risk",
+      "unlikely": "Unlikely",
+      "probable": "Probable",
+      "high": "High probability"
+    },
     "thermal_comfort__thermal_perception": {
       "dry": "A bit dry for some",
       "very_comfortable": "Very comfortable",

--- a/custom_components/thermal_comfort/translations/sensor.fr.json
+++ b/custom_components/thermal_comfort/translations/sensor.fr.json
@@ -1,5 +1,11 @@
 {
   "state": {
+    "thermal_comfort__frost_risk": {
+      "no_risk": "Aucun risque",
+      "unlikely": "Peu probable",
+      "probable": "Probable",
+      "high": "Haute probabilité"
+    },
     "thermal_comfort__thermal_perception": {
       "dry": "Un peu sec pour certains",
       "very_comfortable": "Très confortable",

--- a/custom_components/thermal_comfort/translations/sensor.it.json
+++ b/custom_components/thermal_comfort/translations/sensor.it.json
@@ -1,5 +1,11 @@
 {
   "state": {
+    "thermal_comfort__frost_risk": {
+      "no_risk": "Nessun rischio",
+      "unlikely": "Improbabile",
+      "probable": "Probabile",
+      "high": "Alta probabilità"
+    },
     "thermal_comfort__thermal_perception": {
       "dry": "Un po' secco per alcuni",
       "very_comfortable": "Molto confortabile",


### PR DESCRIPTION
Sorry for doing another PR, had some trouble with rebasing on the last one.

This adds both a frost point and a frost risk sensor as default sensors
to the sensor platform. Both are based on @papo-o's functions, which
where provided by them. See also his fork of thermal comfort for this
sensors https://github.com/papo-o/home-assistant-frost-risks.

See #36

Currently this adds the two new sensors as default because the expected behavior for 1.0.0 is to add all sensors if this config variable is not explicitly set. So it may be confusing for users if we just derivative from that behavior now.