### PR TITLE
feat: configure integration via UI

### DIFF
--- a/custom_components/thermal_comfort/__init__.py
+++ b/custom_components/thermal_comfort/__init__.py
@@ -4,3 +4,55 @@ Custom integration to integrate thermal_comfort with Home Assistant.
 For more details about this integration, please refer to
 https://github.com/dolezsa/thermal_comfort
 """
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_NAME
+from homeassistant.core import HomeAssistant
+
+from .config_flow import get_value
+from .const import (
+    CONF_HUMIDITY_SENSOR,
+    CONF_POLL,
+    CONF_TEMPERATURE_SENSOR,
+    DOMAIN,
+    PLATFORMS,
+    UPDATE_LISTENER,
+)
+from .sensor import SensorType
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up entry configured from user interface."""
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][entry.entry_id] = {
+        CONF_NAME: get_value(entry, CONF_NAME),
+        CONF_TEMPERATURE_SENSOR: get_value(entry, CONF_TEMPERATURE_SENSOR),
+        CONF_HUMIDITY_SENSOR: get_value(entry, CONF_HUMIDITY_SENSOR),
+        CONF_POLL: get_value(entry, CONF_POLL),
+    }
+    if entry.unique_id is None:
+        # We have no unique_id yet, let's use backup.
+        hass.config_entries.async_update_entry(entry, unique_id=entry.entry_id)
+
+    for st in SensorType:
+        hass.data[DOMAIN][entry.entry_id][st] = get_value(entry, st)
+
+    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    update_listener = entry.add_update_listener(async_update_options)
+    hass.data[DOMAIN][entry.entry_id][UPDATE_LISTENER] = update_listener
+    return True
+
+
+async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Update options from user interface."""
+    await hass.config_entries.async_reload(entry.entry_id)
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Remove entry via user interface."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        update_listener = hass.data[DOMAIN][entry.entry_id][UPDATE_LISTENER]
+        update_listener()
+        hass.data[DOMAIN].pop(entry.entry_id)
+    return unload_ok

--- a/custom_components/thermal_comfort/config_flow.py
+++ b/custom_components/thermal_comfort/config_flow.py
@@ -1,0 +1,176 @@
+"""Tests for config flows."""
+from __future__ import annotations
+
+import logging
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_NAME
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry
+import voluptuous as vol
+
+from .const import (
+    CONF_HUMIDITY_SENSOR,
+    CONF_POLL,
+    CONF_TEMPERATURE_SENSOR,
+    DEFAULT_NAME,
+    DOMAIN,
+)
+from .sensor import DEFAULT_SENSOR_TYPES, SensorType
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def get_value(
+    config_entry: config_entries.ConfigEntry | None, param: str, default=None
+):
+    """Get current value for configuration parameter.
+
+    :param config_entry: config_entries|None: config entry from Flow
+    :param param: str: parameter name for getting value
+    :param default: default value for parameter, defaults to None
+    :returns: parameter value, or default value or None
+    """
+    if config_entry is not None:
+        return config_entry.options.get(param, config_entry.data.get(param, default))
+    else:
+        return default
+
+
+def build_schema(
+    config_entry: config_entries | None, show_advanced: bool = False, step: str = "user"
+) -> vol.Schema:
+    """Build configuration schema.
+
+    :param config_entry: config entry for getting current parameters on None
+    :param show_advanced: bool: should we show advanced options?
+    :param step: for which step we should build schema
+    :return: Configuration schema with default parameters
+    """
+    # ToDo: get list of CONF_TEMPERATURE_SENSOR and CONF_HUMIDITY_SENSOR to create dropdown list and "one of" selection
+    schema = vol.Schema(
+        {
+            vol.Required(
+                CONF_NAME, default=get_value(config_entry, CONF_NAME, DEFAULT_NAME)
+            ): str,
+            vol.Required(
+                CONF_TEMPERATURE_SENSOR,
+                default=get_value(config_entry, CONF_TEMPERATURE_SENSOR),
+            ): str,
+            vol.Required(
+                CONF_HUMIDITY_SENSOR,
+                default=get_value(config_entry, CONF_HUMIDITY_SENSOR),
+            ): str,
+        }
+    )
+    if show_advanced:
+        schema = schema.extend(
+            {
+                vol.Optional(
+                    CONF_POLL, default=get_value(config_entry, CONF_POLL, False)
+                ): bool,
+            }
+        )
+        if step == "user":
+            for st in SensorType:
+                default_enable = st in DEFAULT_SENSOR_TYPES
+                schema = schema.extend(
+                    {
+                        vol.Optional(
+                            str(st),
+                            default=get_value(config_entry, str(st), default_enable),
+                        ): bool
+                    }
+                )
+
+    return schema
+
+
+def check_input(hass: HomeAssistant, user_input: dict) -> dict:
+    """Check that we may use suggested configuration.
+
+    :param hass: hass instance
+    :param user_input: user input
+    :returns: dict with error.
+    """
+
+    # ToDo: user_input have ConfigType type, but it in codebase since 2021.12.10
+
+    result = {}
+
+    t_sensor = hass.states.get(user_input[CONF_TEMPERATURE_SENSOR])
+    p_sensor = hass.states.get(user_input[CONF_HUMIDITY_SENSOR])
+
+    if t_sensor is None:
+        result["base"] = "temperature_not_found"
+
+    if p_sensor is None:
+        result["base"] = "humidity_not_found"
+
+    # ToDo: we should not trust user and check:
+    #  - that CONF_TEMPERATURE_SENSOR is temperature sensor and have state_class measurement
+    #  - that CONF_HUMIDITY_SENSOR is humidity sensor and have state_class measurement
+    return result
+
+
+class ThermalComfortConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Configuration flow for setting up new thermal_comfort entry."""
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Get the options flow for this handler."""
+        return ThermalComfortOptionsFlow(config_entry)
+
+    async def async_step_user(self, user_input=None):
+        """Handle a flow initialized by the user."""
+        errors = {}
+
+        if user_input is not None:
+            if not (errors := check_input(self.hass, user_input)):
+                er = entity_registry.async_get(self.hass)
+
+                t_sensor = er.async_get(user_input[CONF_TEMPERATURE_SENSOR])
+                p_sensor = er.async_get(user_input[CONF_HUMIDITY_SENSOR])
+                _LOGGER.debug(f"Going to use t_sensor {t_sensor}")
+                _LOGGER.debug(f"Going to use p_sensor {p_sensor}")
+
+                if t_sensor is not None and p_sensor is not None:
+                    unique_id = f"{t_sensor.unique_id}-{p_sensor.unique_id}"
+                    await self.async_set_unique_id(unique_id)
+                    self._abort_if_unique_id_configured()
+
+                return self.async_create_entry(
+                    title=user_input[CONF_NAME], data=user_input
+                )
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=build_schema(None, self.show_advanced_options),
+            errors=errors,
+        )
+
+
+class ThermalComfortOptionsFlow(config_entries.OptionsFlow):
+    """Handle options."""
+
+    def __init__(self, config_entry):
+        """Initialize options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):
+        """Manage the options."""
+
+        errors = {}
+        if user_input is not None:
+            _LOGGER.debug(f"OptionsFlow: going to update configuration {user_input}")
+            if not (errors := check_input(self.hass, user_input)):
+                return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=build_schema(
+                self.config_entry, self.show_advanced_options, "init"
+            ),
+            errors=errors,
+        )

--- a/custom_components/thermal_comfort/const.py
+++ b/custom_components/thermal_comfort/const.py
@@ -1,4 +1,11 @@
 """General thermal_comfort constants."""
+from homeassistant.const import Platform
+
+DOMAIN = "thermal_comfort"
+PLATFORMS = [Platform.SENSOR]
 CONF_TEMPERATURE_SENSOR = "temperature_sensor"
 CONF_HUMIDITY_SENSOR = "humidity_sensor"
 CONF_POLL = "poll"
+
+DEFAULT_NAME = "Thermal comfort"
+UPDATE_LISTENER = "update_listener"

--- a/custom_components/thermal_comfort/const.py
+++ b/custom_components/thermal_comfort/const.py
@@ -1,0 +1,4 @@
+"""General thermal_comfort constants."""
+CONF_TEMPERATURE_SENSOR = "temperature_sensor"
+CONF_HUMIDITY_SENSOR = "humidity_sensor"
+CONF_POLL = "poll"

--- a/custom_components/thermal_comfort/manifest.json
+++ b/custom_components/thermal_comfort/manifest.json
@@ -5,5 +5,6 @@
   "documentation": "https://github.com/dolezsa/thermal_comfort/blob/master/README.md",
   "issue_tracker": "https://github.com/dolezsa/thermal_comfort/issues",
   "codeowners": ["@dolezsa"],
-  "iot_class": "calculated"
+  "iot_class": "calculated",
+  "config_flow": true
 }

--- a/custom_components/thermal_comfort/sensor.py
+++ b/custom_components/thermal_comfort/sensor.py
@@ -236,14 +236,12 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     return True
 
 
-class SensorThermalComfort(SensorEntity):
+class SensorThermalComfortCommon(SensorEntity):
     """Representation of a Thermal Comfort Sensor."""
 
     def __init__(
         self,
         device,
-        device_id,
-        friendly_name,
         entity_description,
         icon_template,
         entity_picture_template,
@@ -253,10 +251,6 @@ class SensorThermalComfort(SensorEntity):
         """Initialize the sensor."""
         self._device = device
         self.entity_description = entity_description
-        self.entity_description.name = entity_description.name.format(friendly_name)
-        self.entity_id = async_generate_entity_id(
-            ENTITY_ID_FORMAT, f"{device_id}_{sensor_type}", hass=device.hass
-        )
         self._icon_template = icon_template
         self._entity_picture_template = entity_picture_template
         self._attr_icon = None
@@ -323,6 +317,35 @@ class SensorThermalComfort(SensorEntity):
                         self.name,
                         ex,
                     )
+
+
+class SensorThermalComfort(SensorThermalComfortCommon):
+    """Sensor entry configured via configuration.yaml."""
+
+    def __init__(
+        self,
+        device,
+        device_id,
+        friendly_name,
+        entity_description,
+        icon_template,
+        entity_picture_template,
+        sensor_type,
+        unique_id,
+    ):
+        """Initialize sensor entity."""
+        super().__init__(
+            device,
+            entity_description,
+            icon_template,
+            entity_picture_template,
+            sensor_type,
+            unique_id,
+        )
+        self.entity_description.name = entity_description.name.format(friendly_name)
+        self.entity_id = async_generate_entity_id(
+            ENTITY_ID_FORMAT, f"{device_id}_{sensor_type}", hass=device.hass
+        )
 
 
 @dataclass

--- a/custom_components/thermal_comfort/sensor.py
+++ b/custom_components/thermal_comfort/sensor.py
@@ -236,6 +236,16 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     return True
 
 
+def id_generator(unique_id: str, sensor_type: str) -> str:
+    """Generate id based on unique_id and sensor type.
+
+    :param unique_id: str: common part of id for all entities, device unique_id, as a rule
+    :param sensor_type: str: different part of id, sensor type, as s rule
+    :returns: str: unique_id+sensor_type
+    """
+    return unique_id + sensor_type
+
+
 class SensorThermalComfortCommon(SensorEntity):
     """Representation of a Thermal Comfort Sensor."""
 
@@ -259,7 +269,7 @@ class SensorThermalComfortCommon(SensorEntity):
         self._attr_native_value = None
         self._attr_extra_state_attributes = {}
         if unique_id is not None:
-            self._attr_unique_id = unique_id + sensor_type
+            self._attr_unique_id = id_generator(unique_id, sensor_type)
         self._attr_should_poll = self._device.should_poll
 
     @property

--- a/custom_components/thermal_comfort/sensor.py
+++ b/custom_components/thermal_comfort/sensor.py
@@ -34,14 +34,13 @@ from homeassistant.helpers.entity import async_generate_entity_id
 from homeassistant.helpers.event import async_track_state_change_event
 import voluptuous as vol
 
+from .const import CONF_HUMIDITY_SENSOR, CONF_POLL, CONF_TEMPERATURE_SENSOR
+
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_HUMIDITY = "humidity"
 ATTR_FROST_RISK_LEVEL = "frost_risk_level"
-CONF_HUMIDITY_SENSOR = "humidity_sensor"
-CONF_POLL = "poll"
 CONF_SENSOR_TYPES = "sensor_types"
-CONF_TEMPERATURE_SENSOR = "temperature_sensor"
 
 
 class ThermalComfortDeviceClass(StrEnum):

--- a/custom_components/thermal_comfort/translations/en.json
+++ b/custom_components/thermal_comfort/translations/en.json
@@ -1,0 +1,47 @@
+{
+  "options": {
+    "error": {
+      "temperature_not_found": "Temperature sensor not found",
+      "humidity_not_found": "Humidity sensor not found"
+    },
+    "step": {
+      "init": {
+        "title": "Thermal comfort settings",
+        "data": {
+          "temperature_sensor": "Temperature sensor",
+          "humidity_sensor": "Humidity sensor",
+          "poll": "Enable Polling"
+        }
+      }
+    }
+  },
+  "config": {
+    "abort": {
+      "already_configured": "This combination of temperature and humidity sensors is already configured"
+    },
+    "error": {
+      "temperature_not_found": "Temperature sensor not found",
+      "humidity_not_found": "Humidity sensor not found"
+    },
+    "step": {
+      "user": {
+        "title": "Thermal comfort settings",
+        "data": {
+          "name": "Name",
+          "temperature_sensor": "Temperature sensor",
+          "humidity_sensor": "Humidity sensor",
+          "poll": "Enable Polling",
+          "absolutehumidity": "Enable Absolute humidity sensor",
+          "dewpoint": "Enable Dew point sensor",
+          "frostpoint": "Enable Frost point sensor",
+          "frostrisk": "Enable Frost risk sensor",
+          "heatindex": "Enable Heat index sensor",
+          "simmerindex": "Enable Simmer index sensor",
+          "simmerzone": "Enable Simmer zone sensor",
+          "perception": "Enable Perception sensor",
+          "show_advanced_options": "Advanced options"
+        }
+      }
+    }
+  }
+}

--- a/tests/const.py
+++ b/tests/const.py
@@ -1,0 +1,22 @@
+"""General test constants."""
+from homeassistant.const import CONF_NAME
+
+from custom_components.thermal_comfort.const import (
+    CONF_HUMIDITY_SENSOR,
+    CONF_POLL,
+    CONF_TEMPERATURE_SENSOR,
+)
+from custom_components.thermal_comfort.sensor import SensorType
+
+USER_INPUT = {
+    CONF_NAME: "test_thermal_comfort",
+    CONF_TEMPERATURE_SENSOR: "sensor.test_temperature_sensor",
+    CONF_HUMIDITY_SENSOR: "sensor.test_humidity_sensor",
+    CONF_POLL: False,
+}
+
+USER_NEW_INPUT = dict(USER_INPUT)
+USER_NEW_INPUT[CONF_NAME] = "New name"
+
+for i in SensorType:
+    USER_INPUT[i] = True

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,135 @@
+"""Test integration_blueprint config flow."""
+import json
+from unittest.mock import MagicMock, patch
+
+from homeassistant import config_entries, data_entry_flow
+from homeassistant.const import CONF_NAME
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.thermal_comfort.const import (
+    CONF_HUMIDITY_SENSOR,
+    CONF_TEMPERATURE_SENSOR,
+    DOMAIN,
+)
+
+from .const import USER_INPUT, USER_NEW_INPUT
+from .test_sensor import DEFAULT_TEST_SENSORS
+
+
+@pytest.fixture(autouse=True)
+def bypass_setup_fixture():
+    """Prevent setup."""
+    with patch(
+        "custom_components.thermal_comfort.async_setup_entry",
+        return_value=True,
+    ):
+        yield
+
+
+async def _flow_init(hass, advanced_options=True):
+    return await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_USER,
+            "show_advanced_options": advanced_options,
+        },
+    )
+
+
+async def _flow_configure(hass, r, _input=USER_INPUT):
+    with patch(
+        "homeassistant.helpers.entity_registry.EntityRegistry.async_get",
+        return_value=MagicMock(unique_id="foo"),
+    ):
+        return await hass.config_entries.flow.async_configure(
+            r["flow_id"], user_input=_input
+        )
+
+
+@pytest.mark.parametrize("domains", DEFAULT_TEST_SENSORS)
+async def test_successful_config_flow(hass, start_ha):
+    """Test a successful config flow."""
+    # Initialize a config flow
+    result = await _flow_init(hass)
+
+    # Check that the config flow shows the user form as the first step
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+
+    result = await _flow_configure(hass, result)
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+
+    assert result["title"] == USER_INPUT[CONF_NAME]
+    assert result["data"] == USER_INPUT
+    assert result["result"]
+
+
+@pytest.mark.parametrize("domains", DEFAULT_TEST_SENSORS)
+async def test_failed_config_flow(hass, start_ha):
+    """Config flow should fail if ..."""
+
+    # We try to set up second instance for same temperature and humidity sensors
+    for _ in [0, 1]:
+        result = await _flow_init(hass)
+        result = await _flow_configure(hass, result)
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "already_configured"
+
+
+@pytest.mark.parametrize("domains", DEFAULT_TEST_SENSORS)
+async def test_options_flow(hass, start_ha):
+    """Test flow for options changes."""
+    # setup entry
+    entry = MockConfigEntry(domain=DOMAIN, data=USER_INPUT, entry_id="test")
+    entry.add_to_hass(hass)
+
+    # Initialize an options flow for entry
+    result = await hass.config_entries.options.async_init(
+        entry.entry_id, context={"show_advanced_options": True}
+    )
+
+    # Verify that the first options step is a user form
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "init"
+
+    # Enter some data into the form
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input=USER_NEW_INPUT,
+    )
+
+    # Verify that the flow finishes
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == ""
+
+    # Verify that the options were updated
+
+    assert entry.options == USER_NEW_INPUT
+
+
+async def test_config_flow_enabled():
+    """Test is manifest.json have 'config_flow': true."""
+    with open("custom_components/thermal_comfort/manifest.json") as f:
+        manifest = json.load(f)
+        assert manifest.get("config_flow") is True
+
+
+@pytest.mark.parametrize("domains", DEFAULT_TEST_SENSORS)
+@pytest.mark.parametrize("sensor", [CONF_TEMPERATURE_SENSOR, CONF_HUMIDITY_SENSOR])
+async def test_missed_sensors(hass, sensor, start_ha):
+    """Test is we show message if sensor missed."""
+
+    result = await _flow_init(hass)
+
+    # Check that the config flow shows the user form as the first step
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+
+    no_sensor = dict(USER_INPUT)
+    no_sensor[sensor] = "foo"
+    result = await _flow_configure(hass, result, no_sensor)
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,46 @@
+"""Test setup process."""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.thermal_comfort import (
+    async_setup_entry,
+    async_unload_entry,
+    async_update_options,
+)
+from custom_components.thermal_comfort.const import DOMAIN, PLATFORMS
+
+from .const import USER_INPUT
+
+
+async def test_setup_update_unload_entry(hass):
+    """Test entry setup and unload."""
+
+    hass.config_entries.async_setup_platforms = MagicMock()
+    with patch.object(hass.config_entries, "async_update_entry") as p:
+        config_entry = MockConfigEntry(
+            domain=DOMAIN, data=USER_INPUT, entry_id="test", unique_id=None
+        )
+        await hass.config_entries.async_add(config_entry)
+        assert p.called
+
+    assert await async_setup_entry(hass, config_entry)
+    assert DOMAIN in hass.data and config_entry.entry_id in hass.data[DOMAIN]
+
+    # check user input is in config
+    for i in USER_INPUT.keys():
+        assert hass.data[DOMAIN][config_entry.entry_id][i] == USER_INPUT[i]
+
+    hass.config_entries.async_setup_platforms.assert_called_with(
+        config_entry, PLATFORMS
+    )
+
+    # ToDo test hass.data[DOMAIN][config_entry.entry_id][UPDATE_LISTENER]
+
+    hass.config_entries.async_reload = AsyncMock()
+    assert await async_update_options(hass, config_entry) is None
+    hass.config_entries.async_reload.assert_called_with(config_entry.entry_id)
+
+    # Unload the entry and verify that the data has been removed
+    assert await async_unload_entry(hass, config_entry)
+    assert config_entry.entry_id not in hass.data[DOMAIN]

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -4,9 +4,12 @@ import logging
 
 from homeassistant.components import sensor
 from homeassistant.const import ATTR_TEMPERATURE
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry
 import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.thermal_comfort.const import DOMAIN
 from custom_components.thermal_comfort.sensor import (
     ATTR_FROST_RISK_LEVEL,
     ATTR_HUMIDITY,
@@ -14,7 +17,10 @@ from custom_components.thermal_comfort.sensor import (
     SensorType,
     SimmerZone,
     ThermalPerception,
+    id_generator,
 )
+
+from .const import USER_INPUT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -670,3 +676,29 @@ async def test_sensor_unavailable(hass, start_ha):
             hass.states.get(f"{TEST_NAME}_{sensor_type}").attributes[ATTR_HUMIDITY]
             == 50.0
         )
+
+
+async def test_create_sensors(hass: HomeAssistant):
+    """Test sensors update engine.
+
+    When user remove sensor in integration config, then we should remove it from system
+    :param hass: HomeAssistant: Home Assistant object
+    """
+
+    def get_eid(registry: entity_registry, _id):
+        return registry.async_get_entity_id(
+            domain="sensor", platform=DOMAIN, unique_id=_id
+        )
+
+    er = entity_registry.async_get(hass)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN, data=USER_INPUT, entry_id="test", unique_id="uniqueid"
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Make sure that sensors in registry
+    for s in SensorType:
+        assert get_eid(er, id_generator(entry.unique_id, s)) is not None


### PR DESCRIPTION
 - added config flow
 - sensor module refactoring:
   - move necessary const to const
   - create common sensor to support configuration via .yaml and UI at same time

 For future improving:
   1. check user input:
     - temperature sensor muse have temperature unit of measurement
     - humidity sensor must have humidity unit of measurement
   2. replace direct sensor input by dropdown list of suitable sensors

Fix #73