### PR TITLE
New yaml config

### DIFF
--- a/custom_components/thermal_comfort/__init__.py
+++ b/custom_components/thermal_comfort/__init__.py
@@ -4,10 +4,19 @@ Custom integration to integrate thermal_comfort with Home Assistant.
 For more details about this integration, please refer to
 https://github.com/dolezsa/thermal_comfort
 """
+from __future__ import annotations
 
+import logging
+
+from homeassistant.config import async_hass_config_yaml, async_process_component_config
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_NAME
-from homeassistant.core import HomeAssistant
+from homeassistant.const import CONF_NAME, SERVICE_RELOAD
+from homeassistant.core import Event, HomeAssistant, ServiceCall
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import discovery
+from homeassistant.helpers.reload import async_reload_integration_platforms
+from homeassistant.helpers.typing import ConfigType
+from homeassistant.loader import async_get_integration
 
 from .config_flow import get_value
 from .const import (
@@ -19,6 +28,8 @@ from .const import (
     UPDATE_LISTENER,
 )
 from .sensor import SensorType
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -56,3 +67,55 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         update_listener()
         hass.data[DOMAIN].pop(entry.entry_id)
     return unload_ok
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the thermal_comfort integration."""
+    if DOMAIN in config:
+        await _process_config(hass, config)
+
+    async def _reload_config(call: Event | ServiceCall) -> None:
+        """Reload top-level + platforms."""
+        try:
+            unprocessed_conf = await async_hass_config_yaml(hass)
+        except HomeAssistantError as err:
+            _LOGGER.error(err)
+            return
+
+        conf = await async_process_component_config(
+            hass, unprocessed_conf, await async_get_integration(hass, DOMAIN)
+        )
+
+        if conf is None:
+            return
+
+        await async_reload_integration_platforms(hass, DOMAIN, PLATFORMS)
+
+        if DOMAIN in conf:
+            await _process_config(hass, conf)
+
+        hass.bus.async_fire(f"event_{DOMAIN}_reloaded", context=call.context)
+
+    hass.helpers.service.async_register_admin_service(
+        DOMAIN, SERVICE_RELOAD, _reload_config
+    )
+
+    return True
+
+
+async def _process_config(hass: HomeAssistant, hass_config: ConfigType) -> None:
+    """Process config."""
+    for conf_section in hass_config[DOMAIN]:
+        for platform_domain in PLATFORMS:
+            if platform_domain in conf_section:
+                hass.async_create_task(
+                    discovery.async_load_platform(
+                        hass,
+                        platform_domain,
+                        DOMAIN,
+                        {
+                            "devices": conf_section[platform_domain],
+                        },
+                        hass_config,
+                    )
+                )

--- a/custom_components/thermal_comfort/config.py
+++ b/custom_components/thermal_comfort/config.py
@@ -1,0 +1,46 @@
+"""Thermal Comfort config validator."""
+
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.config import async_log_exception, config_without_domain
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.typing import ConfigType
+import voluptuous as vol
+
+from . import sensor as sensor_platform
+from .const import DOMAIN
+
+PACKAGE_MERGE_HINT = "list"
+
+CONFIG_SECTION_SCHEMA = vol.Schema(
+    {
+        vol.Optional(SENSOR_DOMAIN): vol.All(
+            cv.ensure_list, [sensor_platform.SENSOR_SCHEMA]
+        ),
+    }
+)
+
+
+async def async_validate_config(hass: HomeAssistant, config: ConfigType) -> ConfigType:
+    """Validate config."""
+    if DOMAIN not in config:
+        return config
+
+    config_sections = []
+
+    for cfg in cv.ensure_list(config[DOMAIN]):
+        try:
+            cfg = CONFIG_SECTION_SCHEMA(cfg)
+
+        except vol.Invalid as err:
+            async_log_exception(err, DOMAIN, cfg, hass)
+            continue
+
+        config_sections.append(cfg)
+
+    # Create a copy of the configuration with all config for current
+    # component removed and add validated config back in.
+    config = config_without_domain(config, DOMAIN)
+    config[DOMAIN] = config_sections
+
+    return config

--- a/custom_components/thermal_comfort/services.yaml
+++ b/custom_components/thermal_comfort/services.yaml
@@ -1,0 +1,3 @@
+reload:
+  name: Reload
+  description: Reload all Thermal Comfort entities.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,16 +22,16 @@ def calls(hass):
 
 
 @pytest.fixture
-async def start_ha(hass, domains, caplog):
+async def start_ha(hass, domains, config, caplog):
     """Do setup of integration."""
-    for domain, value in domains.items():
-        with assert_setup_component(value["count"], domain):
+    for domain, count in domains:
+        with assert_setup_component(count, domain):
             assert await async_setup_component(
                 hass,
                 domain,
-                value["config"],
+                config,
             )
-            await hass.async_block_till_done()
+        await hass.async_block_till_done()
     await hass.async_start()
     await hass.async_block_till_done()
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -47,7 +47,7 @@ async def _flow_configure(hass, r, _input=USER_INPUT):
         )
 
 
-@pytest.mark.parametrize("domains", DEFAULT_TEST_SENSORS)
+@pytest.mark.parametrize(*DEFAULT_TEST_SENSORS)
 async def test_successful_config_flow(hass, start_ha):
     """Test a successful config flow."""
     # Initialize a config flow
@@ -66,7 +66,7 @@ async def test_successful_config_flow(hass, start_ha):
     assert result["result"]
 
 
-@pytest.mark.parametrize("domains", DEFAULT_TEST_SENSORS)
+@pytest.mark.parametrize(*DEFAULT_TEST_SENSORS)
 async def test_failed_config_flow(hass, start_ha):
     """Config flow should fail if ..."""
 
@@ -79,7 +79,7 @@ async def test_failed_config_flow(hass, start_ha):
     assert result["reason"] == "already_configured"
 
 
-@pytest.mark.parametrize("domains", DEFAULT_TEST_SENSORS)
+@pytest.mark.parametrize(*DEFAULT_TEST_SENSORS)
 async def test_options_flow(hass, start_ha):
     """Test flow for options changes."""
     # setup entry
@@ -117,7 +117,7 @@ async def test_config_flow_enabled():
         assert manifest.get("config_flow") is True
 
 
-@pytest.mark.parametrize("domains", DEFAULT_TEST_SENSORS)
+@pytest.mark.parametrize(*DEFAULT_TEST_SENSORS)
 @pytest.mark.parametrize("sensor", [CONF_TEMPERATURE_SENSOR, CONF_HUMIDITY_SENSOR])
 async def test_missed_sensors(hass, sensor, start_ha):
     """Test is we show message if sensor missed."""

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -65,11 +65,13 @@ DEFAULT_TEST_SENSORS = [
     ],
 ]
 
+LEN_DEFAULT_SENSORS = len(DEFAULT_SENSOR_TYPES)
+
 
 @pytest.mark.parametrize(*DEFAULT_TEST_SENSORS)
 async def test_config(hass, start_ha):
     """Test basic config."""
-    assert len(hass.states.async_all(PLATFORM_DOMAIN)) == 10
+    assert len(hass.states.async_all(PLATFORM_DOMAIN)) == LEN_DEFAULT_SENSORS + 2
 
 
 @pytest.mark.parametrize(*DEFAULT_TEST_SENSORS)
@@ -416,11 +418,11 @@ async def test_simmer_zone(hass, start_ha):
 )
 async def test_unique_id(hass, start_ha):
     """Test if unique id is working as expected."""
-    assert len(hass.states.async_all()) == 18
+    assert len(hass.states.async_all()) == 2 * LEN_DEFAULT_SENSORS + 2
 
     ent_reg = entity_registry.async_get(hass)
 
-    assert len(ent_reg.entities) == 16
+    assert len(ent_reg.entities) == 2 * LEN_DEFAULT_SENSORS
 
     for sensor_type in DEFAULT_SENSOR_TYPES:
         assert (
@@ -465,13 +467,13 @@ async def test_unique_id(hass, start_ha):
 )
 async def test_valid_icon_template(hass, start_ha):
     """Test if icon template is working as expected."""
-    assert len(hass.states.async_all(PLATFORM_DOMAIN)) == 10
+    assert len(hass.states.async_all(PLATFORM_DOMAIN)) == LEN_DEFAULT_SENSORS + 2
 
 
 @pytest.mark.parametrize(*DEFAULT_TEST_SENSORS)
 async def test_zero_degree_celcius(hass, start_ha):
     """Test if zero degree celsius does not cause any errors."""
-    assert len(hass.states.async_all(PLATFORM_DOMAIN)) == 10
+    assert len(hass.states.async_all(PLATFORM_DOMAIN)) == LEN_DEFAULT_SENSORS + 2
     hass.states.async_set("sensor.test_temperature_sensor", "0")
     await hass.async_block_till_done()
     assert hass.states.get(f"{TEST_NAME}_{SensorType.DEWPOINT}") is not None
@@ -553,7 +555,7 @@ async def test_sensor_types(hass, start_ha):
 )
 async def test_sensor_is_nan(hass, start_ha):
     """Test if we correctly handle input sensors with NaN as state value."""
-    assert len(hass.states.async_all(PLATFORM_DOMAIN)) == 10
+    assert len(hass.states.async_all(PLATFORM_DOMAIN)) == LEN_DEFAULT_SENSORS + 2
     for sensor_type in DEFAULT_SENSOR_TYPES:
         assert (
             ATTR_TEMPERATURE
@@ -600,7 +602,7 @@ async def test_sensor_is_nan(hass, start_ha):
 )
 async def test_sensor_unknown(hass, start_ha):
     """Test handling input sensors with unknown state."""
-    assert len(hass.states.async_all(PLATFORM_DOMAIN)) == 10
+    assert len(hass.states.async_all(PLATFORM_DOMAIN)) == LEN_DEFAULT_SENSORS + 2
     for sensor_type in DEFAULT_SENSOR_TYPES:
         assert (
             ATTR_TEMPERATURE
@@ -615,11 +617,11 @@ async def test_sensor_unknown(hass, start_ha):
 @pytest.mark.parametrize(*DEFAULT_TEST_SENSORS)
 async def test_sensor_unavailable(hass, start_ha):
     """Test handling unavailable sensors."""
-    assert len(hass.states.async_all(PLATFORM_DOMAIN)) == 10
+    assert len(hass.states.async_all(PLATFORM_DOMAIN)) == LEN_DEFAULT_SENSORS + 2
     hass.states.async_remove("sensor.test_temperature_sensor")
     hass.states.async_remove("sensor.test_humidity_sensor")
     await hass.async_block_till_done()
-    assert len(hass.states.async_all(PLATFORM_DOMAIN)) == 8
+    assert len(hass.states.async_all(PLATFORM_DOMAIN)) == LEN_DEFAULT_SENSORS
     for sensor_type in DEFAULT_SENSOR_TYPES:
         assert (
             ATTR_TEMPERATURE in hass.states.get(f"{TEST_NAME}_{sensor_type}").attributes

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -62,6 +62,22 @@ DEFAULT_TEST_SENSORS = [
                 ],
             },
         ),
+        (
+            [(PLATFORM_DOMAIN, 2), (DOMAIN, 1)],
+            {
+                PLATFORM_DOMAIN: [
+                    TEMPERATURE_TEST_SENSOR,
+                    HUMIDITY_TEST_SENSOR,
+                ],
+                DOMAIN: {
+                    PLATFORM_DOMAIN: {
+                        "name": "test_thermal_comfort",
+                        "temperature_sensor": "sensor.test_temperature_sensor",
+                        "humidity_sensor": "sensor.test_humidity_sensor",
+                    },
+                },
+            },
+        ),
     ],
 ]
 
@@ -414,6 +430,37 @@ async def test_simmer_zone(hass, start_ha):
                 ],
             },
         ),
+        (
+            [(PLATFORM_DOMAIN, 2), (DOMAIN, 1)],
+            {
+                PLATFORM_DOMAIN: [
+                    TEMPERATURE_TEST_SENSOR,
+                    HUMIDITY_TEST_SENSOR,
+                ],
+                DOMAIN: {
+                    PLATFORM_DOMAIN: [
+                        {
+                            "name": "test_thermal_comfort",
+                            "temperature_sensor": "sensor.test_temperature_sensor",
+                            "humidity_sensor": "sensor.test_humidity_sensor",
+                            "unique_id": "unique",
+                        },
+                        {
+                            "name": "test_thermal_comfort_not_unique1",
+                            "temperature_sensor": "sensor.test_temperature_sensor",
+                            "humidity_sensor": "sensor.test_humidity_sensor",
+                            "unique_id": "not-so-unique-anymore",
+                        },
+                        {
+                            "name": "test_thermal_comfort_not_unique2",
+                            "temperature_sensor": "sensor.test_temperature_sensor",
+                            "humidity_sensor": "sensor.test_humidity_sensor",
+                            "unique_id": "not-so-unique-anymore",
+                        },
+                    ]
+                },
+            },
+        ),
     ],
 )
 async def test_unique_id(hass, start_ha):
@@ -462,7 +509,24 @@ async def test_unique_id(hass, start_ha):
                     },
                 ],
             },
-        )
+        ),
+        (
+            [(PLATFORM_DOMAIN, 2), (DOMAIN, 1)],
+            {
+                PLATFORM_DOMAIN: [
+                    TEMPERATURE_TEST_SENSOR,
+                    HUMIDITY_TEST_SENSOR,
+                ],
+                DOMAIN: {
+                    PLATFORM_DOMAIN: {
+                        "name": "test_thermal_comfort",
+                        "temperature_sensor": "sensor.test_temperature_sensor",
+                        "humidity_sensor": "sensor.test_humidity_sensor",
+                        "icon_template": "mdi:thermometer",
+                    },
+                },
+            },
+        ),
     ],
 )
 async def test_valid_icon_template(hass, start_ha):
@@ -506,7 +570,27 @@ async def test_zero_degree_celcius(hass, start_ha):
                     },
                 ],
             },
-        )
+        ),
+        (
+            [(PLATFORM_DOMAIN, 2), (DOMAIN, 1)],
+            {
+                PLATFORM_DOMAIN: [
+                    TEMPERATURE_TEST_SENSOR,
+                    HUMIDITY_TEST_SENSOR,
+                ],
+                DOMAIN: {
+                    PLATFORM_DOMAIN: {
+                        "name": "test_thermal_comfort",
+                        "temperature_sensor": "sensor.test_temperature_sensor",
+                        "humidity_sensor": "sensor.test_humidity_sensor",
+                        "sensor_types": [
+                            "absolutehumidity",
+                            "dewpoint",
+                        ],
+                    },
+                },
+            },
+        ),
     ],
 )
 async def test_sensor_types(hass, start_ha):
@@ -550,7 +634,33 @@ async def test_sensor_types(hass, start_ha):
                     },
                 ],
             },
-        )
+        ),
+        (
+            [(PLATFORM_DOMAIN, 2), (DOMAIN, 1)],
+            {
+                PLATFORM_DOMAIN: [
+                    {
+                        "platform": COMMAND_LINE_DOMAIN,
+                        "command": "echo 0",
+                        "name": "test_temperature_sensor",
+                        "value_template": "{{ NaN | float }}",
+                    },
+                    {
+                        "platform": COMMAND_LINE_DOMAIN,
+                        "command": "echo 0",
+                        "name": "test_humidity_sensor",
+                        "value_template": "{{ NaN | float }}",
+                    },
+                ],
+                DOMAIN: {
+                    PLATFORM_DOMAIN: {
+                        "name": "test_thermal_comfort",
+                        "temperature_sensor": "sensor.test_temperature_sensor",
+                        "humidity_sensor": "sensor.test_humidity_sensor",
+                    },
+                },
+            },
+        ),
     ],
 )
 async def test_sensor_is_nan(hass, start_ha):
@@ -597,7 +707,33 @@ async def test_sensor_is_nan(hass, start_ha):
                     },
                 ],
             },
-        )
+        ),
+        (
+            [(PLATFORM_DOMAIN, 2), (DOMAIN, 1)],
+            {
+                PLATFORM_DOMAIN: [
+                    {
+                        "platform": COMMAND_LINE_DOMAIN,
+                        "command": "echo 0",
+                        "name": "test_temperature_sensor",
+                        "value_template": "{{ NaN | float }}",
+                    },
+                    {
+                        "platform": COMMAND_LINE_DOMAIN,
+                        "command": "echo 0",
+                        "name": "test_humidity_sensor",
+                        "value_template": "{{ NaN | float }}",
+                    },
+                ],
+                DOMAIN: {
+                    PLATFORM_DOMAIN: {
+                        "name": "test_thermal_comfort",
+                        "temperature_sensor": "sensor.test_temperature_sensor",
+                        "humidity_sensor": "sensor.test_humidity_sensor",
+                    },
+                },
+            },
+        ),
     ],
 )
 async def test_sensor_unknown(hass, start_ha):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2,7 +2,8 @@
 
 import logging
 
-from homeassistant.components import sensor
+from homeassistant.components.command_line.const import DOMAIN as COMMAND_LINE_DOMAIN
+from homeassistant.components.sensor import DOMAIN as PLATFORM_DOMAIN
 from homeassistant.const import ATTR_TEMPERATURE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry
@@ -25,49 +26,53 @@ from .const import USER_INPUT
 _LOGGER = logging.getLogger(__name__)
 
 TEST_NAME = "sensor.test_thermal_comfort"
+
+TEMPERATURE_TEST_SENSOR = {
+    "platform": COMMAND_LINE_DOMAIN,
+    "command": "echo 0",
+    "name": "test_temperature_sensor",
+    "value_template": "{{ 25.0 | float }}",
+}
+
+HUMIDITY_TEST_SENSOR = {
+    "platform": COMMAND_LINE_DOMAIN,
+    "command": "echo 0",
+    "name": "test_humidity_sensor",
+    "value_template": "{{ 50.0 | float }}",
+}
+
 DEFAULT_TEST_SENSORS = [
-    (
-        {
-            sensor.DOMAIN: {
-                "count": 3,
-                "config": {
-                    sensor.DOMAIN: [
-                        {
-                            "platform": "command_line",
-                            "command": "echo 0",
-                            "name": "test_temperature_sensor",
-                            "value_template": "{{ 25.0 | float }}",
-                        },
-                        {
-                            "platform": "command_line",
-                            "command": "echo 0",
-                            "name": "test_humidity_sensor",
-                            "value_template": "{{ 50.0 | float }}",
-                        },
-                        {
-                            "platform": "thermal_comfort",
-                            "sensors": {
-                                "test_thermal_comfort": {
-                                    "temperature_sensor": "sensor.test_temperature_sensor",
-                                    "humidity_sensor": "sensor.test_humidity_sensor",
-                                },
+    "domains, config",
+    [
+        (
+            [(PLATFORM_DOMAIN, 3)],
+            {
+                PLATFORM_DOMAIN: [
+                    TEMPERATURE_TEST_SENSOR,
+                    HUMIDITY_TEST_SENSOR,
+                    {
+                        "platform": DOMAIN,
+                        "sensors": {
+                            "test_thermal_comfort": {
+                                "temperature_sensor": "sensor.test_temperature_sensor",
+                                "humidity_sensor": "sensor.test_humidity_sensor",
                             },
                         },
-                    ],
-                },
+                    },
+                ],
             },
-        }
-    )
+        ),
+    ],
 ]
 
 
-@pytest.mark.parametrize("domains", DEFAULT_TEST_SENSORS)
+@pytest.mark.parametrize(*DEFAULT_TEST_SENSORS)
 async def test_config(hass, start_ha):
     """Test basic config."""
-    assert len(hass.states.async_all(sensor.DOMAIN)) == 10
+    assert len(hass.states.async_all(PLATFORM_DOMAIN)) == 10
 
 
-@pytest.mark.parametrize("domains", DEFAULT_TEST_SENSORS)
+@pytest.mark.parametrize(*DEFAULT_TEST_SENSORS)
 async def test_properties(hass, start_ha):
     """Test if properties are set up correctly."""
     for sensor_type in DEFAULT_SENSOR_TYPES:
@@ -85,7 +90,7 @@ async def test_properties(hass, start_ha):
         )
 
 
-@pytest.mark.parametrize("domains", DEFAULT_TEST_SENSORS)
+@pytest.mark.parametrize(*DEFAULT_TEST_SENSORS)
 async def test_absolutehumidity(hass, start_ha):
     """Test if absolute humidity is calculted correctly."""
     assert hass.states.get(f"{TEST_NAME}_{SensorType.ABSOLUTEHUMIDITY}") is not None
@@ -102,7 +107,7 @@ async def test_absolutehumidity(hass, start_ha):
     assert hass.states.get(f"{TEST_NAME}_{SensorType.ABSOLUTEHUMIDITY}").state == "3.2"
 
 
-@pytest.mark.parametrize("domains", DEFAULT_TEST_SENSORS)
+@pytest.mark.parametrize(*DEFAULT_TEST_SENSORS)
 async def test_heatindex(hass, start_ha):
     """Test if heat index is calculated correctly."""
     assert hass.states.get(f"{TEST_NAME}_{SensorType.HEATINDEX}") is not None
@@ -123,7 +128,7 @@ async def test_heatindex(hass, start_ha):
     assert hass.states.get(f"{TEST_NAME}_{SensorType.HEATINDEX}").state == "26.55"
 
 
-@pytest.mark.parametrize("domains", DEFAULT_TEST_SENSORS)
+@pytest.mark.parametrize(*DEFAULT_TEST_SENSORS)
 async def test_dew_point(hass, start_ha):
     """Test if dew point is calculated correctly."""
     assert hass.states.get(f"{TEST_NAME}_{SensorType.DEWPOINT}") is not None
@@ -138,7 +143,7 @@ async def test_dew_point(hass, start_ha):
     assert hass.states.get(f"{TEST_NAME}_{SensorType.DEWPOINT}").state == "-4.86"
 
 
-@pytest.mark.parametrize("domains", DEFAULT_TEST_SENSORS)
+@pytest.mark.parametrize(*DEFAULT_TEST_SENSORS)
 async def test_perception(hass, start_ha):
     """Test if perception is calculated correctly."""
     hass.states.async_set("sensor.test_temperature_sensor", "20.77")
@@ -213,7 +218,7 @@ async def test_perception(hass, start_ha):
     )
 
 
-@pytest.mark.parametrize("domains", DEFAULT_TEST_SENSORS)
+@pytest.mark.parametrize(*DEFAULT_TEST_SENSORS)
 async def test_frost_point(hass, start_ha):
     """Test if frost point is calculated correctly."""
     assert hass.states.get(f"{TEST_NAME}_{SensorType.FROSTPOINT}") is not None
@@ -228,7 +233,7 @@ async def test_frost_point(hass, start_ha):
     assert hass.states.get(f"{TEST_NAME}_{SensorType.FROSTPOINT}").state == "-6.81"
 
 
-@pytest.mark.parametrize("domains", DEFAULT_TEST_SENSORS)
+@pytest.mark.parametrize(*DEFAULT_TEST_SENSORS)
 async def test_frost_risk(hass, start_ha):
     """Test if frost risk is calculated correctly."""
     assert hass.states.get(f"{TEST_NAME}_{SensorType.FROSTRISK}") is not None
@@ -274,7 +279,7 @@ async def test_frost_risk(hass, start_ha):
     )
 
 
-@pytest.mark.parametrize("domains", DEFAULT_TEST_SENSORS)
+@pytest.mark.parametrize(*DEFAULT_TEST_SENSORS)
 async def test_simmer_index(hass, start_ha):
     """Test if simmer index is calculated correctly."""
     assert hass.states.get(f"{TEST_NAME}_{SensorType.SIMMERINDEX}") is not None
@@ -291,7 +296,7 @@ async def test_simmer_index(hass, start_ha):
     assert hass.states.get(f"{TEST_NAME}_{SensorType.SIMMERINDEX}").state == "27.88"
 
 
-@pytest.mark.parametrize("domains", DEFAULT_TEST_SENSORS)
+@pytest.mark.parametrize(*DEFAULT_TEST_SENSORS)
 async def test_simmer_zone(hass, start_ha):
     """Test if simmer zone is calculated correctly."""
     hass.states.async_set("sensor.test_temperature_sensor", "20.77")
@@ -376,51 +381,37 @@ async def test_simmer_zone(hass, start_ha):
 
 
 @pytest.mark.parametrize(
-    "domains",
+    "domains, config",
     [
         (
+            [(PLATFORM_DOMAIN, 3)],
             {
-                sensor.DOMAIN: {
-                    "count": 3,
-                    "config": {
-                        sensor.DOMAIN: [
-                            {
-                                "platform": "command_line",
-                                "command": "echo 0",
-                                "name": "test_temperature_sensor",
-                                "value_template": "{{ 25.0 | float }}",
+                PLATFORM_DOMAIN: [
+                    TEMPERATURE_TEST_SENSOR,
+                    HUMIDITY_TEST_SENSOR,
+                    {
+                        "platform": DOMAIN,
+                        "sensors": {
+                            "test_thermal_comfort": {
+                                "temperature_sensor": "sensor.test_temperature_sensor",
+                                "humidity_sensor": "sensor.test_humidity_sensor",
+                                "unique_id": "unique",
                             },
-                            {
-                                "platform": "command_line",
-                                "command": "echo 0",
-                                "name": "test_humidity_sensor",
-                                "value_template": "{{ 50.0 | float }}",
+                            "test_thermal_comfort_not_unique1": {
+                                "temperature_sensor": "sensor.test_temperature_sensor",
+                                "humidity_sensor": "sensor.test_humidity_sensor",
+                                "unique_id": "not-so-unique-anymore",
                             },
-                            {
-                                "platform": "thermal_comfort",
-                                "sensors": {
-                                    "test_thermal_comfort": {
-                                        "temperature_sensor": "sensor.test_temperature_sensor",
-                                        "humidity_sensor": "sensor.test_humidity_sensor",
-                                        "unique_id": "unique",
-                                    },
-                                    "test_thermal_comfort_not_unique1": {
-                                        "temperature_sensor": "sensor.test_temperature_sensor",
-                                        "humidity_sensor": "sensor.test_humidity_sensor",
-                                        "unique_id": "not-so-unique-anymore",
-                                    },
-                                    "test_thermal_comfort_not_unique2": {
-                                        "temperature_sensor": "sensor.test_temperature_sensor",
-                                        "humidity_sensor": "sensor.test_humidity_sensor",
-                                        "unique_id": "not-so-unique-anymore",
-                                    },
-                                },
+                            "test_thermal_comfort_not_unique2": {
+                                "temperature_sensor": "sensor.test_temperature_sensor",
+                                "humidity_sensor": "sensor.test_humidity_sensor",
+                                "unique_id": "not-so-unique-anymore",
                             },
-                        ],
+                        },
                     },
-                },
-            }
-        )
+                ],
+            },
+        ),
     ],
 )
 async def test_unique_id(hass, start_ha):
@@ -434,65 +425,53 @@ async def test_unique_id(hass, start_ha):
     for sensor_type in DEFAULT_SENSOR_TYPES:
         assert (
             ent_reg.async_get_entity_id(
-                sensor.DOMAIN, "thermal_comfort", f"unique{sensor_type}"
+                PLATFORM_DOMAIN, "thermal_comfort", f"unique{sensor_type}"
             )
             is not None
         )
         assert (
             ent_reg.async_get_entity_id(
-                sensor.DOMAIN, "thermal_comfort", f"not-so-unique-anymore{sensor_type}"
+                PLATFORM_DOMAIN,
+                "thermal_comfort",
+                f"not-so-unique-anymore{sensor_type}",
             )
             is not None
         )
 
 
 @pytest.mark.parametrize(
-    "domains",
+    "domains, config",
     [
         (
+            [(PLATFORM_DOMAIN, 3)],
             {
-                sensor.DOMAIN: {
-                    "count": 3,
-                    "config": {
-                        sensor.DOMAIN: [
-                            {
-                                "platform": "command_line",
-                                "command": "echo 0",
-                                "name": "test_temperature_sensor",
-                                "value_template": "{{ 25.0 | float }}",
+                PLATFORM_DOMAIN: [
+                    TEMPERATURE_TEST_SENSOR,
+                    HUMIDITY_TEST_SENSOR,
+                    {
+                        "platform": DOMAIN,
+                        "sensors": {
+                            "test_thermal_comfort": {
+                                "temperature_sensor": "sensor.test_temperature_sensor",
+                                "humidity_sensor": "sensor.test_humidity_sensor",
+                                "icon_template": "mdi:thermometer",
                             },
-                            {
-                                "platform": "command_line",
-                                "command": "echo 0",
-                                "name": "test_humidity_sensor",
-                                "value_template": "{{ 50.0 | float }}",
-                            },
-                            {
-                                "platform": "thermal_comfort",
-                                "sensors": {
-                                    "test_thermal_comfort": {
-                                        "temperature_sensor": "sensor.test_temperature_sensor",
-                                        "humidity_sensor": "sensor.test_humidity_sensor",
-                                        "icon_template": "mdi:thermometer",
-                                    },
-                                },
-                            },
-                        ],
+                        },
                     },
-                },
-            }
+                ],
+            },
         )
     ],
 )
 async def test_valid_icon_template(hass, start_ha):
     """Test if icon template is working as expected."""
-    assert len(hass.states.async_all(sensor.DOMAIN)) == 10
+    assert len(hass.states.async_all(PLATFORM_DOMAIN)) == 10
 
 
-@pytest.mark.parametrize("domains", DEFAULT_TEST_SENSORS)
+@pytest.mark.parametrize(*DEFAULT_TEST_SENSORS)
 async def test_zero_degree_celcius(hass, start_ha):
     """Test if zero degree celsius does not cause any errors."""
-    assert len(hass.states.async_all(sensor.DOMAIN)) == 10
+    assert len(hass.states.async_all(PLATFORM_DOMAIN)) == 10
     hass.states.async_set("sensor.test_temperature_sensor", "0")
     await hass.async_block_till_done()
     assert hass.states.get(f"{TEST_NAME}_{SensorType.DEWPOINT}") is not None
@@ -502,49 +481,35 @@ async def test_zero_degree_celcius(hass, start_ha):
 
 
 @pytest.mark.parametrize(
-    "domains",
+    "domains, config",
     [
         (
+            [(PLATFORM_DOMAIN, 3)],
             {
-                sensor.DOMAIN: {
-                    "count": 3,
-                    "config": {
-                        sensor.DOMAIN: [
-                            {
-                                "platform": "command_line",
-                                "command": "echo 0",
-                                "name": "test_temperature_sensor",
-                                "value_template": "{{ 25.0 | float }}",
+                PLATFORM_DOMAIN: [
+                    TEMPERATURE_TEST_SENSOR,
+                    HUMIDITY_TEST_SENSOR,
+                    {
+                        "platform": "thermal_comfort",
+                        "sensors": {
+                            "test_thermal_comfort": {
+                                "temperature_sensor": "sensor.test_temperature_sensor",
+                                "humidity_sensor": "sensor.test_humidity_sensor",
+                                "sensor_types": [
+                                    "absolutehumidity",
+                                    "dewpoint",
+                                ],
                             },
-                            {
-                                "platform": "command_line",
-                                "command": "echo 0",
-                                "name": "test_humidity_sensor",
-                                "value_template": "{{ 50.0 | float }}",
-                            },
-                            {
-                                "platform": "thermal_comfort",
-                                "sensors": {
-                                    "test_thermal_comfort": {
-                                        "temperature_sensor": "sensor.test_temperature_sensor",
-                                        "humidity_sensor": "sensor.test_humidity_sensor",
-                                        "sensor_types": [
-                                            "absolutehumidity",
-                                            "dewpoint",
-                                        ],
-                                    },
-                                },
-                            },
-                        ],
+                        },
                     },
-                },
-            }
+                ],
+            },
         )
     ],
 )
 async def test_sensor_types(hass, start_ha):
     """Test if configure sensor_types only creates the sensors specified."""
-    assert len(hass.states.async_all(sensor.DOMAIN)) == 4
+    assert len(hass.states.async_all(PLATFORM_DOMAIN)) == 4
 
     assert hass.states.get(f"{TEST_NAME}_{SensorType.HEATINDEX}") is None
     assert hass.states.get(f"{TEST_NAME}_{SensorType.THERMALPERCEPTION}") is None
@@ -554,45 +519,41 @@ async def test_sensor_types(hass, start_ha):
 
 
 @pytest.mark.parametrize(
-    "domains",
+    "domains, config",
     [
         (
+            [(PLATFORM_DOMAIN, 3)],
             {
-                sensor.DOMAIN: {
-                    "count": 3,
-                    "config": {
-                        sensor.DOMAIN: [
-                            {
-                                "platform": "command_line",
-                                "command": "echo 0",
-                                "name": "test_temperature_sensor",
-                                "value_template": "{{ NaN | float }}",
-                            },
-                            {
-                                "platform": "command_line",
-                                "command": "echo 0",
-                                "name": "test_humidity_sensor",
-                                "value_template": "{{ NaN | float }}",
-                            },
-                            {
-                                "platform": "thermal_comfort",
-                                "sensors": {
-                                    "test_thermal_comfort": {
-                                        "temperature_sensor": "sensor.test_temperature_sensor",
-                                        "humidity_sensor": "sensor.test_humidity_sensor",
-                                    },
-                                },
-                            },
-                        ],
+                PLATFORM_DOMAIN: [
+                    {
+                        "platform": COMMAND_LINE_DOMAIN,
+                        "command": "echo 0",
+                        "name": "test_temperature_sensor",
+                        "value_template": "{{ NaN | float }}",
                     },
-                },
-            }
+                    {
+                        "platform": COMMAND_LINE_DOMAIN,
+                        "command": "echo 0",
+                        "name": "test_humidity_sensor",
+                        "value_template": "{{ NaN | float }}",
+                    },
+                    {
+                        "platform": DOMAIN,
+                        "sensors": {
+                            "test_thermal_comfort": {
+                                "temperature_sensor": "sensor.test_temperature_sensor",
+                                "humidity_sensor": "sensor.test_humidity_sensor",
+                            },
+                        },
+                    },
+                ],
+            },
         )
     ],
 )
 async def test_sensor_is_nan(hass, start_ha):
     """Test if we correctly handle input sensors with NaN as state value."""
-    assert len(hass.states.async_all(sensor.DOMAIN)) == 10
+    assert len(hass.states.async_all(PLATFORM_DOMAIN)) == 10
     for sensor_type in DEFAULT_SENSOR_TYPES:
         assert (
             ATTR_TEMPERATURE
@@ -605,45 +566,41 @@ async def test_sensor_is_nan(hass, start_ha):
 
 
 @pytest.mark.parametrize(
-    "domains",
+    "domains, config",
     [
         (
+            [(PLATFORM_DOMAIN, 3)],
             {
-                sensor.DOMAIN: {
-                    "count": 3,
-                    "config": {
-                        sensor.DOMAIN: [
-                            {
-                                "platform": "command_line",
-                                "command": "echo 0",
-                                "name": "test_temperature_sensor",
-                                "value_template": "{{ 'Unknown' }}",
-                            },
-                            {
-                                "platform": "command_line",
-                                "command": "echo 0",
-                                "name": "test_humidity_sensor",
-                                "value_template": "{{ 'asdf' }}",
-                            },
-                            {
-                                "platform": "thermal_comfort",
-                                "sensors": {
-                                    "test_thermal_comfort": {
-                                        "temperature_sensor": "sensor.test_temperature_sensor",
-                                        "humidity_sensor": "sensor.test_humidity_sensor",
-                                    },
-                                },
-                            },
-                        ],
+                PLATFORM_DOMAIN: [
+                    {
+                        "platform": COMMAND_LINE_DOMAIN,
+                        "command": "echo 0",
+                        "name": "test_temperature_sensor",
+                        "value_template": "{{ 'Unknown' }}",
                     },
-                },
-            }
+                    {
+                        "platform": COMMAND_LINE_DOMAIN,
+                        "command": "echo 0",
+                        "name": "test_humidity_sensor",
+                        "value_template": "{{ 'asdf' }}",
+                    },
+                    {
+                        "platform": DOMAIN,
+                        "sensors": {
+                            "test_thermal_comfort": {
+                                "temperature_sensor": "sensor.test_temperature_sensor",
+                                "humidity_sensor": "sensor.test_humidity_sensor",
+                            },
+                        },
+                    },
+                ],
+            },
         )
     ],
 )
 async def test_sensor_unknown(hass, start_ha):
     """Test handling input sensors with unknown state."""
-    assert len(hass.states.async_all(sensor.DOMAIN)) == 10
+    assert len(hass.states.async_all(PLATFORM_DOMAIN)) == 10
     for sensor_type in DEFAULT_SENSOR_TYPES:
         assert (
             ATTR_TEMPERATURE
@@ -655,14 +612,14 @@ async def test_sensor_unknown(hass, start_ha):
         )
 
 
-@pytest.mark.parametrize("domains", DEFAULT_TEST_SENSORS)
+@pytest.mark.parametrize(*DEFAULT_TEST_SENSORS)
 async def test_sensor_unavailable(hass, start_ha):
     """Test handling unavailable sensors."""
-    assert len(hass.states.async_all(sensor.DOMAIN)) == 10
+    assert len(hass.states.async_all(PLATFORM_DOMAIN)) == 10
     hass.states.async_remove("sensor.test_temperature_sensor")
     hass.states.async_remove("sensor.test_humidity_sensor")
     await hass.async_block_till_done()
-    assert len(hass.states.async_all(sensor.DOMAIN)) == 8
+    assert len(hass.states.async_all(PLATFORM_DOMAIN)) == 8
     for sensor_type in DEFAULT_SENSOR_TYPES:
         assert (
             ATTR_TEMPERATURE in hass.states.get(f"{TEST_NAME}_{sensor_type}").attributes


### PR DESCRIPTION
This adds async_setup to the thermal_comfort integration and allows to
setup the platforms under integration domain key.
e.g.
```yaml
thermal_comfort:
  - sensor:
    - temperature_sensor: sensor.kitchen_temperature
      humidity_sensor: sensor.kitchen_humidity
```

With this commit the thermal_comfort integration supports both the old
legacy configuration under the platform key e.g. sensor and the new
configuration under integration domain key.

The `friendly_name` config key has been renamed to `name` and takes up
the role as both friendly name and identifier = entity_id.
This requires user intervention when converting the old
configurations to new ones.

e.g.
```yaml
sensor:
  - platform: thermal_comfort
    sensors:
      old_kitchen:
        friendly_name: Old Kitchen
        temperature_sensor: sensor.kitchen_temperature
        humidity_sensor: sensor.kitchen_humidity
```
would need to be changed to
```yaml
thermal_comfort:
  - sensor:
    - name: Old Kitchen
      temperature_sensor: sensor.kitchen_temperature
      humidity_sensor: sensor.kitchen_humidity
```