### PR TITLE
Rename sensor types

### DIFF
--- a/custom_components/thermal_comfort/translations/en.json
+++ b/custom_components/thermal_comfort/translations/en.json
@@ -31,14 +31,14 @@
           "temperature_sensor": "Temperature sensor",
           "humidity_sensor": "Humidity sensor",
           "poll": "Enable Polling",
-          "absolutehumidity": "Enable Absolute humidity sensor",
-          "dewpoint": "Enable Dew point sensor",
-          "frostpoint": "Enable Frost point sensor",
-          "frostrisk": "Enable Frost risk sensor",
-          "heatindex": "Enable Heat index sensor",
-          "simmerindex": "Enable Simmer index sensor",
-          "simmerzone": "Enable Simmer zone sensor",
-          "perception": "Enable Perception sensor",
+          "absolute_humidity": "Enable Absolute humidity sensor",
+          "dew_point": "Enable Dew point sensor",
+          "frost_point": "Enable Frost point sensor",
+          "frost_risk": "Enable Frost risk sensor",
+          "heat_index": "Enable Heat index sensor",
+          "simmer_index": "Enable Simmer index sensor",
+          "simmer_zone": "Enable Simmer zone sensor",
+          "thermal_perception": "Enable Perception sensor",
           "show_advanced_options": "Advanced options"
         }
       }

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,6 +1,7 @@
 """The test for the Thermal Comfort sensor platform."""
 
 import logging
+from typing import Callable
 
 from homeassistant.components.command_line.const import DOMAIN as COMMAND_LINE_DOMAIN
 from homeassistant.components.sensor import DOMAIN as PLATFORM_DOMAIN
@@ -84,6 +85,12 @@ DEFAULT_TEST_SENSORS = [
 LEN_DEFAULT_SENSORS = len(DEFAULT_SENSOR_TYPES)
 
 
+def get_sensor(hass, sensor_type: SensorType) -> str:
+    """Get test sensor id."""
+    # TODO deprecate shortform in 2.0
+    return hass.states.get(f"{TEST_NAME}_{sensor_type.to_shortform()}")
+
+
 @pytest.mark.parametrize(*DEFAULT_TEST_SENSORS)
 async def test_config(hass, start_ha):
     """Test basic config."""
@@ -94,71 +101,61 @@ async def test_config(hass, start_ha):
 async def test_properties(hass, start_ha):
     """Test if properties are set up correctly."""
     for sensor_type in DEFAULT_SENSOR_TYPES:
-        assert (
-            ATTR_TEMPERATURE in hass.states.get(f"{TEST_NAME}_{sensor_type}").attributes
-        )
-        assert ATTR_HUMIDITY in hass.states.get(f"{TEST_NAME}_{sensor_type}").attributes
-        assert (
-            hass.states.get(f"{TEST_NAME}_{sensor_type}").attributes[ATTR_TEMPERATURE]
-            == 25.0
-        )
-        assert (
-            hass.states.get(f"{TEST_NAME}_{sensor_type}").attributes[ATTR_HUMIDITY]
-            == 50.0
-        )
+        assert ATTR_TEMPERATURE in get_sensor(hass, sensor_type).attributes
+        assert ATTR_HUMIDITY in get_sensor(hass, sensor_type).attributes
+        assert get_sensor(hass, sensor_type).attributes[ATTR_TEMPERATURE] == 25.0
+        assert get_sensor(hass, sensor_type).attributes[ATTR_HUMIDITY] == 50.0
 
 
 @pytest.mark.parametrize(*DEFAULT_TEST_SENSORS)
 async def test_absolutehumidity(hass, start_ha):
     """Test if absolute humidity is calculted correctly."""
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.ABSOLUTEHUMIDITY}") is not None
-    assert (
-        hass.states.get(f"{TEST_NAME}_{SensorType.ABSOLUTEHUMIDITY}").state == "11.51"
-    )
+    assert get_sensor(hass, SensorType.ABSOLUTE_HUMIDITY) is not None
+    assert get_sensor(hass, SensorType.ABSOLUTE_HUMIDITY).state == "11.51"
 
     hass.states.async_set("sensor.test_temperature_sensor", "15.0")
     await hass.async_block_till_done()
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.ABSOLUTEHUMIDITY}").state == "6.41"
+    assert get_sensor(hass, SensorType.ABSOLUTE_HUMIDITY).state == "6.41"
 
     hass.states.async_set("sensor.test_humidity_sensor", "25.0")
     await hass.async_block_till_done()
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.ABSOLUTEHUMIDITY}").state == "3.2"
+    assert get_sensor(hass, SensorType.ABSOLUTE_HUMIDITY).state == "3.2"
 
 
 @pytest.mark.parametrize(*DEFAULT_TEST_SENSORS)
 async def test_heatindex(hass, start_ha):
     """Test if heat index is calculated correctly."""
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.HEATINDEX}") is not None
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.HEATINDEX}").state == "24.86"
+    assert get_sensor(hass, SensorType.HEAT_INDEX) is not None
+    assert get_sensor(hass, SensorType.HEAT_INDEX).state == "24.86"
 
     hass.states.async_set("sensor.test_temperature_sensor", "15.0")
     await hass.async_block_till_done()
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.HEATINDEX}").state == "13.86"
+    assert get_sensor(hass, SensorType.HEAT_INDEX).state == "13.86"
 
     hass.states.async_set("sensor.test_humidity_sensor", "25.0")
     await hass.async_block_till_done()
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.HEATINDEX}").state == "13.21"
+    assert get_sensor(hass, SensorType.HEAT_INDEX).state == "13.21"
 
     hass.states.async_set("sensor.test_humidity_sensor", "12.0")
     await hass.async_block_till_done()
     hass.states.async_set("sensor.test_temperature_sensor", "28.0")
     await hass.async_block_till_done()
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.HEATINDEX}").state == "26.55"
+    assert get_sensor(hass, SensorType.HEAT_INDEX).state == "26.55"
 
 
 @pytest.mark.parametrize(*DEFAULT_TEST_SENSORS)
 async def test_dew_point(hass, start_ha):
     """Test if dew point is calculated correctly."""
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.DEWPOINT}") is not None
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.DEWPOINT}").state == "13.88"
+    assert get_sensor(hass, SensorType.DEW_POINT) is not None
+    assert get_sensor(hass, SensorType.DEW_POINT).state == "13.88"
 
     hass.states.async_set("sensor.test_temperature_sensor", "15.0")
     await hass.async_block_till_done()
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.DEWPOINT}").state == "4.68"
+    assert get_sensor(hass, SensorType.DEW_POINT).state == "4.68"
 
     hass.states.async_set("sensor.test_humidity_sensor", "25.0")
     await hass.async_block_till_done()
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.DEWPOINT}").state == "-4.86"
+    assert get_sensor(hass, SensorType.DEW_POINT).state == "-4.86"
 
 
 @pytest.mark.parametrize(*DEFAULT_TEST_SENSORS)
@@ -166,42 +163,41 @@ async def test_perception(hass, start_ha):
     """Test if perception is calculated correctly."""
     hass.states.async_set("sensor.test_temperature_sensor", "20.77")
     await hass.async_block_till_done()
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.THERMALPERCEPTION}") is not None
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.DEWPOINT}").state == "9.99"
+    assert get_sensor(hass, SensorType.THERMAL_PERCEPTION) is not None
+    assert get_sensor(hass, SensorType.DEW_POINT).state == "9.99"
     assert (
-        hass.states.get(f"{TEST_NAME}_{SensorType.THERMALPERCEPTION}").state
-        == ThermalPerception.DRY
+        get_sensor(hass, SensorType.THERMAL_PERCEPTION).state == ThermalPerception.DRY
     )
 
     hass.states.async_set("sensor.test_temperature_sensor", "24.0")
     await hass.async_block_till_done()
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.DEWPOINT}").state == "12.96"
+    assert get_sensor(hass, SensorType.DEW_POINT).state == "12.96"
     assert (
-        hass.states.get(f"{TEST_NAME}_{SensorType.THERMALPERCEPTION}").state
+        get_sensor(hass, SensorType.THERMAL_PERCEPTION).state
         == ThermalPerception.VERY_COMFORTABLE
     )
 
     hass.states.async_set("sensor.test_humidity_sensor", "60.82")
     await hass.async_block_till_done()
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.DEWPOINT}").state == "15.99"
+    assert get_sensor(hass, SensorType.DEW_POINT).state == "15.99"
     assert (
-        hass.states.get(f"{TEST_NAME}_{SensorType.THERMALPERCEPTION}").state
+        get_sensor(hass, SensorType.THERMAL_PERCEPTION).state
         == ThermalPerception.COMFORTABLE
     )
 
     hass.states.async_set("sensor.test_temperature_sensor", "24.01")
     await hass.async_block_till_done()
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.DEWPOINT}").state == "16.0"
+    assert get_sensor(hass, SensorType.DEW_POINT).state == "16.0"
     assert (
-        hass.states.get(f"{TEST_NAME}_{SensorType.THERMALPERCEPTION}").state
+        get_sensor(hass, SensorType.THERMAL_PERCEPTION).state
         == ThermalPerception.OK_BUT_HUMID
     )
 
     hass.states.async_set("sensor.test_humidity_sensor", "69.03")
     await hass.async_block_till_done()
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.DEWPOINT}").state == "18.0"
+    assert get_sensor(hass, SensorType.DEW_POINT).state == "18.0"
     assert (
-        hass.states.get(f"{TEST_NAME}_{SensorType.THERMALPERCEPTION}").state
+        get_sensor(hass, SensorType.THERMAL_PERCEPTION).state
         == ThermalPerception.SOMEWHAT_UNCOMFORTABLE
     )
 
@@ -209,9 +205,9 @@ async def test_perception(hass, start_ha):
     await hass.async_block_till_done()
     hass.states.async_set("sensor.test_temperature_sensor", "26.0")
     await hass.async_block_till_done()
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.DEWPOINT}").state == "22.22"
+    assert get_sensor(hass, SensorType.DEW_POINT).state == "22.22"
     assert (
-        hass.states.get(f"{TEST_NAME}_{SensorType.THERMALPERCEPTION}").state
+        get_sensor(hass, SensorType.THERMAL_PERCEPTION).state
         == ThermalPerception.QUITE_UNCOMFORTABLE
     )
 
@@ -219,9 +215,9 @@ async def test_perception(hass, start_ha):
     await hass.async_block_till_done()
     hass.states.async_set("sensor.test_temperature_sensor", "26.85")
     await hass.async_block_till_done()
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.DEWPOINT}").state == "24.13"
+    assert get_sensor(hass, SensorType.DEW_POINT).state == "24.13"
     assert (
-        hass.states.get(f"{TEST_NAME}_{SensorType.THERMALPERCEPTION}").state
+        get_sensor(hass, SensorType.THERMAL_PERCEPTION).state
         == ThermalPerception.EXTREMELY_UNCOMFORTABLE
     )
 
@@ -229,9 +225,9 @@ async def test_perception(hass, start_ha):
     await hass.async_block_till_done()
     hass.states.async_set("sensor.test_temperature_sensor", "26.85")
     await hass.async_block_till_done()
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.DEWPOINT}").state == "26.0"
+    assert get_sensor(hass, SensorType.DEW_POINT).state == "26.0"
     assert (
-        hass.states.get(f"{TEST_NAME}_{SensorType.THERMALPERCEPTION}").state
+        get_sensor(hass, SensorType.THERMAL_PERCEPTION).state
         == ThermalPerception.SEVERELY_HIGH
     )
 
@@ -239,79 +235,67 @@ async def test_perception(hass, start_ha):
 @pytest.mark.parametrize(*DEFAULT_TEST_SENSORS)
 async def test_frost_point(hass, start_ha):
     """Test if frost point is calculated correctly."""
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.FROSTPOINT}") is not None
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.FROSTPOINT}").state == "10.43"
+    assert get_sensor(hass, SensorType.FROST_POINT) is not None
+    assert get_sensor(hass, SensorType.FROST_POINT).state == "10.43"
 
     hass.states.async_set("sensor.test_temperature_sensor", "15.0")
     await hass.async_block_till_done()
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.FROSTPOINT}").state == "2.73"
+    assert get_sensor(hass, SensorType.FROST_POINT).state == "2.73"
 
     hass.states.async_set("sensor.test_humidity_sensor", "25.0")
     await hass.async_block_till_done()
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.FROSTPOINT}").state == "-6.81"
+    assert get_sensor(hass, SensorType.FROST_POINT).state == "-6.81"
 
 
 @pytest.mark.parametrize(*DEFAULT_TEST_SENSORS)
 async def test_frost_risk(hass, start_ha):
     """Test if frost risk is calculated correctly."""
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.FROSTRISK}") is not None
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.FROSTRISK}").state == "no_risk"
+    assert get_sensor(hass, SensorType.FROST_RISK) is not None
+    assert get_sensor(hass, SensorType.FROST_RISK).state == "no_risk"
     assert (
-        hass.states.get(f"{TEST_NAME}_{SensorType.FROSTRISK}").attributes[
-            ATTR_FROST_RISK_LEVEL
-        ]
-        == 0
+        get_sensor(hass, SensorType.FROST_RISK).attributes[ATTR_FROST_RISK_LEVEL] == 0
     )
 
     hass.states.async_set("sensor.test_temperature_sensor", "0")
     hass.states.async_set("sensor.test_humidity_sensor", "57.7")
     await hass.async_block_till_done()
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.FROSTRISK}").state == "unlikely"
+    assert get_sensor(hass, SensorType.FROST_RISK).state == "unlikely"
     assert (
-        hass.states.get(f"{TEST_NAME}_{SensorType.FROSTRISK}").attributes[
-            ATTR_FROST_RISK_LEVEL
-        ]
-        == 1
+        get_sensor(hass, SensorType.FROST_RISK).attributes[ATTR_FROST_RISK_LEVEL] == 1
     )
 
     hass.states.async_set("sensor.test_temperature_sensor", "4.0")
     hass.states.async_set("sensor.test_humidity_sensor", "80.65")
     await hass.async_block_till_done()
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.FROSTRISK}").state == "probable"
+    assert get_sensor(hass, SensorType.FROST_RISK).state == "probable"
     assert (
-        hass.states.get(f"{TEST_NAME}_{SensorType.FROSTRISK}").attributes[
-            ATTR_FROST_RISK_LEVEL
-        ]
-        == 2
+        get_sensor(hass, SensorType.FROST_RISK).attributes[ATTR_FROST_RISK_LEVEL] == 2
     )
 
     hass.states.async_set("sensor.test_temperature_sensor", "1.0")
     hass.states.async_set("sensor.test_humidity_sensor", "90.00")
     await hass.async_block_till_done()
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.FROSTRISK}").state == "high"
+    assert get_sensor(hass, SensorType.FROST_RISK).state == "high"
     assert (
-        hass.states.get(f"{TEST_NAME}_{SensorType.FROSTRISK}").attributes[
-            ATTR_FROST_RISK_LEVEL
-        ]
-        == 3
+        get_sensor(hass, SensorType.FROST_RISK).attributes[ATTR_FROST_RISK_LEVEL] == 3
     )
 
 
 @pytest.mark.parametrize(*DEFAULT_TEST_SENSORS)
 async def test_simmer_index(hass, start_ha):
     """Test if simmer index is calculated correctly."""
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.SIMMERINDEX}") is not None
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.SIMMERINDEX}").state == "29.6"
+    assert get_sensor(hass, SensorType.SIMMER_INDEX) is not None
+    assert get_sensor(hass, SensorType.SIMMER_INDEX).state == "29.6"
 
     hass.states.async_set("sensor.test_temperature_sensor", "15.0")
     await hass.async_block_till_done()
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.SIMMERINDEX}").state == "15.0"
+    assert get_sensor(hass, SensorType.SIMMER_INDEX).state == "15.0"
 
     hass.states.async_set("sensor.test_humidity_sensor", "35.0")
     await hass.async_block_till_done()
     hass.states.async_set("sensor.test_temperature_sensor", "25.0")
     await hass.async_block_till_done()
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.SIMMERINDEX}").state == "27.88"
+    assert get_sensor(hass, SensorType.SIMMER_INDEX).state == "27.88"
 
 
 @pytest.mark.parametrize(*DEFAULT_TEST_SENSORS)
@@ -319,51 +303,37 @@ async def test_simmer_zone(hass, start_ha):
     """Test if simmer zone is calculated correctly."""
     hass.states.async_set("sensor.test_temperature_sensor", "20.77")
     await hass.async_block_till_done()
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.SIMMERZONE}") is not None
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.SIMMERINDEX}").state == "20.77"
-    assert (
-        hass.states.get(f"{TEST_NAME}_{SensorType.SIMMERZONE}").state == SimmerZone.COOL
-    )
+    assert get_sensor(hass, SensorType.SIMMER_ZONE) is not None
+    assert get_sensor(hass, SensorType.SIMMER_INDEX).state == "20.77"
+    assert get_sensor(hass, SensorType.SIMMER_ZONE).state == SimmerZone.COOL
 
     hass.states.async_set("sensor.test_temperature_sensor", "24.0")
     await hass.async_block_till_done()
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.SIMMERINDEX}").state == "28.17"
-    assert (
-        hass.states.get(f"{TEST_NAME}_{SensorType.SIMMERZONE}").state
-        == SimmerZone.COMFORTABLE
-    )
+    assert get_sensor(hass, SensorType.SIMMER_INDEX).state == "28.17"
+    assert get_sensor(hass, SensorType.SIMMER_ZONE).state == SimmerZone.COMFORTABLE
 
     hass.states.async_set("sensor.test_humidity_sensor", "60.82")
     await hass.async_block_till_done()
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.SIMMERINDEX}").state == "29.29"
-    assert (
-        hass.states.get(f"{TEST_NAME}_{SensorType.SIMMERZONE}").state
-        == SimmerZone.SLIGHTLY_WARM
-    )
+    assert get_sensor(hass, SensorType.SIMMER_INDEX).state == "29.29"
+    assert get_sensor(hass, SensorType.SIMMER_ZONE).state == SimmerZone.SLIGHTLY_WARM
 
     hass.states.async_set("sensor.test_temperature_sensor", "24.01")
     await hass.async_block_till_done()
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.SIMMERINDEX}").state == "29.31"
-    assert (
-        hass.states.get(f"{TEST_NAME}_{SensorType.SIMMERZONE}").state
-        == SimmerZone.SLIGHTLY_WARM
-    )
+    assert get_sensor(hass, SensorType.SIMMER_INDEX).state == "29.31"
+    assert get_sensor(hass, SensorType.SIMMER_ZONE).state == SimmerZone.SLIGHTLY_WARM
 
     hass.states.async_set("sensor.test_humidity_sensor", "69.03")
     await hass.async_block_till_done()
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.SIMMERINDEX}").state == "30.16"
-    assert (
-        hass.states.get(f"{TEST_NAME}_{SensorType.SIMMERZONE}").state
-        == SimmerZone.SLIGHTLY_WARM
-    )
+    assert get_sensor(hass, SensorType.SIMMER_INDEX).state == "30.16"
+    assert get_sensor(hass, SensorType.SIMMER_ZONE).state == SimmerZone.SLIGHTLY_WARM
 
     hass.states.async_set("sensor.test_humidity_sensor", "79.6")
     await hass.async_block_till_done()
     hass.states.async_set("sensor.test_temperature_sensor", "26.0")
     await hass.async_block_till_done()
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.SIMMERINDEX}").state == "34.76"
+    assert get_sensor(hass, SensorType.SIMMER_INDEX).state == "34.76"
     assert (
-        hass.states.get(f"{TEST_NAME}_{SensorType.SIMMERZONE}").state
+        get_sensor(hass, SensorType.SIMMER_ZONE).state
         == SimmerZone.INCREASING_DISCOMFORT
     )
 
@@ -371,9 +341,9 @@ async def test_simmer_zone(hass, start_ha):
     await hass.async_block_till_done()
     hass.states.async_set("sensor.test_temperature_sensor", "26.85")
     await hass.async_block_till_done()
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.SIMMERINDEX}").state == "36.99"
+    assert get_sensor(hass, SensorType.SIMMER_INDEX).state == "36.99"
     assert (
-        hass.states.get(f"{TEST_NAME}_{SensorType.SIMMERZONE}").state
+        get_sensor(hass, SensorType.SIMMER_ZONE).state
         == SimmerZone.INCREASING_DISCOMFORT
     )
 
@@ -381,19 +351,16 @@ async def test_simmer_zone(hass, start_ha):
     await hass.async_block_till_done()
     hass.states.async_set("sensor.test_temperature_sensor", "29.0")
     await hass.async_block_till_done()
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.SIMMERINDEX}").state == "40.1"
-    assert (
-        hass.states.get(f"{TEST_NAME}_{SensorType.SIMMERZONE}").state
-        == SimmerZone.EXTREMELY_WARM
-    )
+    assert get_sensor(hass, SensorType.SIMMER_INDEX).state == "40.1"
+    assert get_sensor(hass, SensorType.SIMMER_ZONE).state == SimmerZone.EXTREMELY_WARM
 
     hass.states.async_set("sensor.test_humidity_sensor", "45.0")
     await hass.async_block_till_done()
     hass.states.async_set("sensor.test_temperature_sensor", "40.0")
     await hass.async_block_till_done()
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.SIMMERINDEX}").state == "49.74"
+    assert get_sensor(hass, SensorType.SIMMER_INDEX).state == "49.74"
     assert (
-        hass.states.get(f"{TEST_NAME}_{SensorType.SIMMERZONE}").state
+        get_sensor(hass, SensorType.SIMMER_ZONE).state
         == SimmerZone.DANGER_OF_HEATSTROKE
     )
 
@@ -540,10 +507,10 @@ async def test_zero_degree_celcius(hass, start_ha):
     assert len(hass.states.async_all(PLATFORM_DOMAIN)) == LEN_DEFAULT_SENSORS + 2
     hass.states.async_set("sensor.test_temperature_sensor", "0")
     await hass.async_block_till_done()
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.DEWPOINT}") is not None
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.DEWPOINT}").state == "-9.19"
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.SIMMERINDEX}") is not None
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.SIMMERINDEX}").state == "0.0"
+    assert get_sensor(hass, SensorType.DEW_POINT) is not None
+    assert get_sensor(hass, SensorType.DEW_POINT).state == "-9.19"
+    assert get_sensor(hass, SensorType.SIMMER_INDEX) is not None
+    assert get_sensor(hass, SensorType.SIMMER_INDEX).state == "0.0"
 
 
 @pytest.mark.parametrize(
@@ -562,8 +529,8 @@ async def test_zero_degree_celcius(hass, start_ha):
                                 "temperature_sensor": "sensor.test_temperature_sensor",
                                 "humidity_sensor": "sensor.test_humidity_sensor",
                                 "sensor_types": [
-                                    "absolutehumidity",
-                                    "dewpoint",
+                                    SensorType.ABSOLUTE_HUMIDITY,
+                                    SensorType.DEW_POINT,
                                 ],
                             },
                         },
@@ -584,8 +551,8 @@ async def test_zero_degree_celcius(hass, start_ha):
                         "temperature_sensor": "sensor.test_temperature_sensor",
                         "humidity_sensor": "sensor.test_humidity_sensor",
                         "sensor_types": [
-                            "absolutehumidity",
-                            "dewpoint",
+                            SensorType.ABSOLUTE_HUMIDITY,
+                            SensorType.DEW_POINT,
                         ],
                     },
                 },
@@ -593,15 +560,15 @@ async def test_zero_degree_celcius(hass, start_ha):
         ),
     ],
 )
-async def test_sensor_types(hass, start_ha):
+async def get_sensor_types(hass, start_ha):
     """Test if configure sensor_types only creates the sensors specified."""
     assert len(hass.states.async_all(PLATFORM_DOMAIN)) == 4
 
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.HEATINDEX}") is None
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.THERMALPERCEPTION}") is None
+    assert get_sensor(hass, SensorType.HEAT_INDEX) is None
+    assert get_sensor(hass, SensorType.THERMAL_PERCEPTION) is None
 
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.ABSOLUTEHUMIDITY}") is not None
-    assert hass.states.get(f"{TEST_NAME}_{SensorType.DEWPOINT}") is not None
+    assert get_sensor(hass, SensorType.ABSOLUTE_HUMIDITY) is not None
+    assert get_sensor(hass, SensorType.DEW_POINT) is not None
 
 
 @pytest.mark.parametrize(
@@ -663,18 +630,12 @@ async def test_sensor_types(hass, start_ha):
         ),
     ],
 )
-async def test_sensor_is_nan(hass, start_ha):
+async def get_sensor_is_nan(hass, start_ha):
     """Test if we correctly handle input sensors with NaN as state value."""
     assert len(hass.states.async_all(PLATFORM_DOMAIN)) == LEN_DEFAULT_SENSORS + 2
     for sensor_type in DEFAULT_SENSOR_TYPES:
-        assert (
-            ATTR_TEMPERATURE
-            not in hass.states.get(f"{TEST_NAME}_{sensor_type}").attributes
-        )
-        assert (
-            ATTR_HUMIDITY
-            not in hass.states.get(f"{TEST_NAME}_{sensor_type}").attributes
-        )
+        assert ATTR_TEMPERATURE not in get_sensor(hass, sensor_type).attributes
+        assert ATTR_HUMIDITY not in get_sensor(hass, sensor_type).attributes
 
 
 @pytest.mark.parametrize(
@@ -736,22 +697,16 @@ async def test_sensor_is_nan(hass, start_ha):
         ),
     ],
 )
-async def test_sensor_unknown(hass, start_ha):
+async def get_sensor_unknown(hass, start_ha):
     """Test handling input sensors with unknown state."""
     assert len(hass.states.async_all(PLATFORM_DOMAIN)) == LEN_DEFAULT_SENSORS + 2
     for sensor_type in DEFAULT_SENSOR_TYPES:
-        assert (
-            ATTR_TEMPERATURE
-            not in hass.states.get(f"{TEST_NAME}_{sensor_type}").attributes
-        )
-        assert (
-            ATTR_HUMIDITY
-            not in hass.states.get(f"{TEST_NAME}_{sensor_type}").attributes
-        )
+        assert ATTR_TEMPERATURE not in get_sensor(hass, sensor_type).attributes
+        assert ATTR_HUMIDITY not in get_sensor(hass, sensor_type).attributes
 
 
 @pytest.mark.parametrize(*DEFAULT_TEST_SENSORS)
-async def test_sensor_unavailable(hass, start_ha):
+async def get_sensor_unavailable(hass, start_ha):
     """Test handling unavailable sensors."""
     assert len(hass.states.async_all(PLATFORM_DOMAIN)) == LEN_DEFAULT_SENSORS + 2
     hass.states.async_remove("sensor.test_temperature_sensor")
@@ -759,18 +714,10 @@ async def test_sensor_unavailable(hass, start_ha):
     await hass.async_block_till_done()
     assert len(hass.states.async_all(PLATFORM_DOMAIN)) == LEN_DEFAULT_SENSORS
     for sensor_type in DEFAULT_SENSOR_TYPES:
-        assert (
-            ATTR_TEMPERATURE in hass.states.get(f"{TEST_NAME}_{sensor_type}").attributes
-        )
-        assert ATTR_HUMIDITY in hass.states.get(f"{TEST_NAME}_{sensor_type}").attributes
-        assert (
-            hass.states.get(f"{TEST_NAME}_{sensor_type}").attributes[ATTR_TEMPERATURE]
-            == 25.0
-        )
-        assert (
-            hass.states.get(f"{TEST_NAME}_{sensor_type}").attributes[ATTR_HUMIDITY]
-            == 50.0
-        )
+        assert ATTR_TEMPERATURE in get_sensor(hass, sensor_type).attributes
+        assert ATTR_HUMIDITY in get_sensor(hass, sensor_type).attributes
+        assert get_sensor(hass, sensor_type).attributes[ATTR_TEMPERATURE] == 25.0
+        assert get_sensor(hass, sensor_type).attributes[ATTR_HUMIDITY] == 50.0
 
 
 async def test_create_sensors(hass: HomeAssistant):
@@ -797,3 +744,68 @@ async def test_create_sensors(hass: HomeAssistant):
     # Make sure that sensors in registry
     for s in SensorType:
         assert get_eid(er, id_generator(entry.unique_id, s)) is not None
+
+
+async def test_sensor_type_from_shortform() -> None:
+    """Test if sensor types are correctly converted from shortform."""
+    assert SensorType.from_shortform("absolutehumidity") == SensorType.ABSOLUTE_HUMIDITY
+    assert SensorType.from_shortform("dewpoint") == SensorType.DEW_POINT
+    assert SensorType.from_shortform("frostpoint") == SensorType.FROST_POINT
+    assert SensorType.from_shortform("frostrisk") == SensorType.FROST_RISK
+    assert SensorType.from_shortform("heatindex") == SensorType.HEAT_INDEX
+    assert SensorType.from_shortform("simmerindex") == SensorType.SIMMER_INDEX
+    assert SensorType.from_shortform("simmerzone") == SensorType.SIMMER_ZONE
+    assert SensorType.from_shortform("perception") == SensorType.THERMAL_PERCEPTION
+    with pytest.raises(ValueError) as error:
+        SensorType.from_shortform("unknown")
+    assert "Unknown sensor type: unknown" in str(error.value)
+
+
+@pytest.mark.parametrize(
+    "domains, config",
+    [
+        (
+            [(PLATFORM_DOMAIN, 1)],
+            {
+                PLATFORM_DOMAIN: [
+                    {
+                        "platform": "thermal_comfort",
+                        "sensors": {
+                            "test_thermal_comfort": {
+                                "temperature_sensor": "sensor.test_temperature_sensor",
+                                "humidity_sensor": "sensor.test_humidity_sensor",
+                                "sensor_types": [
+                                    SensorType.THERMAL_PERCEPTION.to_shortform()
+                                ],
+                            },
+                        },
+                    },
+                ],
+            },
+        ),
+        (
+            [(DOMAIN, 1)],
+            {
+                DOMAIN: {
+                    PLATFORM_DOMAIN: {
+                        "name": "test_thermal_comfort",
+                        "temperature_sensor": "sensor.test_temperature_sensor",
+                        "humidity_sensor": "sensor.test_humidity_sensor",
+                        "sensor_types": [SensorType.THERMAL_PERCEPTION.to_shortform()],
+                    },
+                },
+            },
+        ),
+    ],
+)
+async def test_sensor_type_names(hass: HomeAssistant, start_ha: Callable) -> None:
+    """Test if sensor types shortform can be used."""
+    assert len(hass.states.async_all(PLATFORM_DOMAIN)) == 1
+    assert (
+        get_sensor(hass, SensorType.THERMAL_PERCEPTION).entity_id
+        == f"{PLATFORM_DOMAIN}.test_thermal_comfort_{SensorType.THERMAL_PERCEPTION.to_shortform()}"
+    )
+    assert (
+        SensorType.THERMAL_PERCEPTION.to_title()
+        in get_sensor(hass, SensorType.THERMAL_PERCEPTION).name
+    )


### PR DESCRIPTION
This splits up all sensor types into seperate words for readability and
string manipulation. Currently this is implemented in a backward
compatible way.

The new sensor type names are separated by a underscore
`_`. e.g. `dew_point`.

The old sensor names are called shortform and are available through
SensorType.TYPE.shortform(). The shortform is still used in places where
it otherwise would cause a user breaking change. e.g. entity_id

SensorType also offers a from_shortform constructor so we can support
the old shortform in yaml for the sensor_types list.

SensorType also offers a to_title() method which creates replaces the
underscore with a space and capitalizes the first letters of every word.
e.g. used in sensor names.