### PR TITLE
feat: add sensor selection from list in configuration via UI

### DIFF
--- a/custom_components/thermal_comfort/config_flow.py
+++ b/custom_components/thermal_comfort/config_flow.py
@@ -186,7 +186,11 @@ class ThermalComfortConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="user",
-            data_schema=build_schema(None, self.hass, self.show_advanced_options),
+            data_schema=build_schema(
+                config_entry=None,
+                hass=self.hass,
+                show_advanced=self.show_advanced_options,
+            ),
             errors=errors,
         )
 
@@ -210,7 +214,10 @@ class ThermalComfortOptionsFlow(config_entries.OptionsFlow):
         return self.async_show_form(
             step_id="init",
             data_schema=build_schema(
-                self.config_entry, self.hass, self.show_advanced_options, "init"
+                config_entry=self.config_entry,
+                hass=self.hass,
+                show_advanced=self.show_advanced_options,
+                step="init",
             ),
             errors=errors,
         )

--- a/custom_components/thermal_comfort/config_flow.py
+++ b/custom_components/thermal_comfort/config_flow.py
@@ -94,11 +94,11 @@ def build_schema(
             ): str,
             vol.Required(
                 CONF_TEMPERATURE_SENSOR,
-                default=get_value(config_entry, CONF_TEMPERATURE_SENSOR),
+                default=get_value(config_entry, CONF_TEMPERATURE_SENSOR, t_sensors[0]),
             ): vol.In(t_sensors),
             vol.Required(
                 CONF_HUMIDITY_SENSOR,
-                default=get_value(config_entry, CONF_HUMIDITY_SENSOR),
+                default=get_value(config_entry, CONF_HUMIDITY_SENSOR, h_sensors[0]),
             ): vol.In(h_sensors),
         },
     )

--- a/custom_components/thermal_comfort/config_flow.py
+++ b/custom_components/thermal_comfort/config_flow.py
@@ -28,7 +28,10 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def get_sensors_by_device_class(
-    _er: EntityRegistry, _hass: HomeAssistant, device_class: str
+    _er: EntityRegistry,
+    _hass: HomeAssistant,
+    device_class: str,
+    include_not_in_registry: bool = False,
 ) -> list:
     """Get sensors of required class from entity registry."""
 
@@ -39,11 +42,11 @@ def get_sensors_by_device_class(
         for e in d.values():
             result.append(e)
 
-    # add entities that not in registry.
-    result += list(
-        {e.entity_id for e in _hass.states.async_all()}
-        - {e.entity_id for e in _er.entities}
-    )
+    if include_not_in_registry:
+        result += list(
+            {e.entity_id for e in _hass.states.async_all()}
+            - {e.entity_id for e in _er.entities}
+        )
     return result
 
 
@@ -78,8 +81,12 @@ def build_schema(
     :return: Configuration schema with default parameters
     """
     er = entity_registry.async_get(hass)
-    h_sensors = get_sensors_by_device_class(er, hass, DEVICE_CLASS_HUMIDITY)
-    t_sensors = get_sensors_by_device_class(er, hass, DEVICE_CLASS_TEMPERATURE)
+    h_sensors = get_sensors_by_device_class(
+        er, hass, DEVICE_CLASS_HUMIDITY, show_advanced
+    )
+    t_sensors = get_sensors_by_device_class(
+        er, hass, DEVICE_CLASS_TEMPERATURE, show_advanced
+    )
 
     schema = vol.Schema(
         {

--- a/custom_components/thermal_comfort/config_flow.py
+++ b/custom_components/thermal_comfort/config_flow.py
@@ -31,68 +31,6 @@ def get_sensors_by_device_class(
 ) -> list:
     """Get sensors of required class from entity registry."""
 
-    DEVICE_CLASS_FOR_EXCLUDE = [
-        SensorDeviceClass.AQI,
-        SensorDeviceClass.BATTERY,
-        SensorDeviceClass.CO,
-        SensorDeviceClass.CO2,
-        SensorDeviceClass.CURRENT,
-        SensorDeviceClass.DATE,
-        SensorDeviceClass.ENERGY,
-        SensorDeviceClass.FREQUENCY,
-        SensorDeviceClass.GAS,
-        SensorDeviceClass.ILLUMINANCE,
-        SensorDeviceClass.MONETARY,
-        SensorDeviceClass.NITROGEN_DIOXIDE,
-        SensorDeviceClass.NITROGEN_MONOXIDE,
-        SensorDeviceClass.NITROUS_OXIDE,
-        SensorDeviceClass.OZONE,
-        SensorDeviceClass.PM1,
-        SensorDeviceClass.PM10,
-        SensorDeviceClass.PM25,
-        SensorDeviceClass.POWER_FACTOR,
-        SensorDeviceClass.POWER,
-        SensorDeviceClass.PRESSURE,
-        SensorDeviceClass.SIGNAL_STRENGTH,
-        SensorDeviceClass.SULPHUR_DIOXIDE,
-        SensorDeviceClass.TIMESTAMP,
-        SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS,
-        SensorDeviceClass.VOLTAGE,
-    ]
-    """We are sure that this device classes could not be useful as data source in any case"""
-
-    DOMAINS_FOR_EXCLUDE = [
-        Platform.AIR_QUALITY,
-        Platform.ALARM_CONTROL_PANEL,
-        Platform.BINARY_SENSOR,
-        Platform.BUTTON,
-        Platform.CALENDAR,
-        Platform.CAMERA,
-        Platform.COVER,
-        Platform.DEVICE_TRACKER,
-        Platform.FAN,
-        Platform.GEO_LOCATION,
-        Platform.IMAGE_PROCESSING,
-        Platform.LIGHT,
-        Platform.LOCK,
-        Platform.MAILBOX,
-        Platform.MEDIA_PLAYER,
-        Platform.NOTIFY,
-        Platform.REMOTE,
-        Platform.SCENE,
-        Platform.SIREN,
-        Platform.STT,
-        Platform.TTS,
-        Platform.VACUUM,
-        "automation",
-        "person",
-        "script",
-        "scene",
-        "timer",
-        "zone",
-    ]
-    """We are sure that this domains could not be useful as data source in any case"""
-
     def filter_by_device_class(
         _state: State, _list: list[SensorDeviceClass], should_be_in: bool = True
     ) -> bool:
@@ -109,12 +47,72 @@ def get_sensors_by_device_class(
         )
 
     def filter_useless_device_class(state: State) -> bool:
+        device_class_for_exclude = [
+            SensorDeviceClass.AQI,
+            SensorDeviceClass.BATTERY,
+            SensorDeviceClass.CO,
+            SensorDeviceClass.CO2,
+            SensorDeviceClass.CURRENT,
+            SensorDeviceClass.DATE,
+            SensorDeviceClass.ENERGY,
+            SensorDeviceClass.FREQUENCY,
+            SensorDeviceClass.GAS,
+            SensorDeviceClass.ILLUMINANCE,
+            SensorDeviceClass.MONETARY,
+            SensorDeviceClass.NITROGEN_DIOXIDE,
+            SensorDeviceClass.NITROGEN_MONOXIDE,
+            SensorDeviceClass.NITROUS_OXIDE,
+            SensorDeviceClass.OZONE,
+            SensorDeviceClass.PM1,
+            SensorDeviceClass.PM10,
+            SensorDeviceClass.PM25,
+            SensorDeviceClass.POWER_FACTOR,
+            SensorDeviceClass.POWER,
+            SensorDeviceClass.PRESSURE,
+            SensorDeviceClass.SIGNAL_STRENGTH,
+            SensorDeviceClass.SULPHUR_DIOXIDE,
+            SensorDeviceClass.TIMESTAMP,
+            SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS,
+            SensorDeviceClass.VOLTAGE,
+        ]
+        """We are sure that this device classes could not be useful as data source in any case"""
         return filter_by_device_class(
-            state, DEVICE_CLASS_FOR_EXCLUDE, should_be_in=False
+            state, device_class_for_exclude, should_be_in=False
         )
 
     def filter_useless_domain(state: State) -> bool:
-        return state.domain not in DOMAINS_FOR_EXCLUDE
+        domains_for_exclude = [
+            Platform.AIR_QUALITY,
+            Platform.ALARM_CONTROL_PANEL,
+            Platform.BINARY_SENSOR,
+            Platform.BUTTON,
+            Platform.CALENDAR,
+            Platform.CAMERA,
+            Platform.COVER,
+            Platform.DEVICE_TRACKER,
+            Platform.FAN,
+            Platform.GEO_LOCATION,
+            Platform.IMAGE_PROCESSING,
+            Platform.LIGHT,
+            Platform.LOCK,
+            Platform.MAILBOX,
+            Platform.MEDIA_PLAYER,
+            Platform.NOTIFY,
+            Platform.REMOTE,
+            Platform.SCENE,
+            Platform.SIREN,
+            Platform.STT,
+            Platform.TTS,
+            Platform.VACUUM,
+            "automation",
+            "person",
+            "script",
+            "scene",
+            "timer",
+            "zone",
+        ]
+        """We are sure that this domains could not be useful as data source in any case"""
+        return state.domain not in domains_for_exclude
 
     def filter_useless_units(state: State) -> bool:
         units_for_exclude = [

--- a/custom_components/thermal_comfort/config_flow.py
+++ b/custom_components/thermal_comfort/config_flow.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 import logging
 
 from homeassistant import config_entries
+from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import (
     CONF_NAME,
-    DEVICE_CLASS_HUMIDITY,
-    DEVICE_CLASS_TEMPERATURE,
     Platform,
 )
 from homeassistant.core import HomeAssistant, callback
@@ -82,10 +81,10 @@ def build_schema(
     """
     entity_registry_instance = entity_registry.async_get(hass)
     humidity_sensors = get_sensors_by_device_class(
-        entity_registry_instance, hass, DEVICE_CLASS_HUMIDITY, show_advanced
+        entity_registry_instance, hass, SensorDeviceClass.HUMIDITY, show_advanced
     )
     temperature_sensors = get_sensors_by_device_class(
-        entity_registry_instance, hass, DEVICE_CLASS_TEMPERATURE, show_advanced
+        entity_registry_instance, hass, SensorDeviceClass.TEMPERATURE, show_advanced
     )
 
     schema = vol.Schema(

--- a/custom_components/thermal_comfort/config_flow.py
+++ b/custom_components/thermal_comfort/config_flow.py
@@ -44,7 +44,7 @@ def get_sensors_by_device_class(
 
     if include_not_in_registry:
         result += list(
-            {e.entity_id for e in _hass.states.async_all()} - {e for e in _er.entities}
+            {e.entity_id for e in _hass.states.async_all()} - set(_er.entities)
         )
     return result
 

--- a/custom_components/thermal_comfort/config_flow.py
+++ b/custom_components/thermal_comfort/config_flow.py
@@ -34,6 +34,12 @@ def get_sensors_by_device_class(
     def filter_by_device_class(
         _state: State, _list: list[SensorDeviceClass], should_be_in: bool = True
     ) -> bool:
+        """Filter state objects by device class.
+
+        :param _state: state object for examination
+        :param _list: list of device classes
+        :param should_be_in: should the object's device_class be in the list to pass the filter or not
+        """
         collected_device_class = _state.attributes.get(
             "device_class", _state.attributes.get("original_device_class")
         )
@@ -47,6 +53,7 @@ def get_sensors_by_device_class(
         )
 
     def filter_useless_device_class(state: State) -> bool:
+        """Filter out states with useless for us device class."""
         device_class_for_exclude = [
             SensorDeviceClass.AQI,
             SensorDeviceClass.BATTERY,
@@ -81,6 +88,7 @@ def get_sensors_by_device_class(
         )
 
     def filter_useless_domain(state: State) -> bool:
+        """Filter states with useless for us domains."""
         domains_for_exclude = [
             Platform.AIR_QUALITY,
             Platform.ALARM_CONTROL_PANEL,
@@ -115,6 +123,7 @@ def get_sensors_by_device_class(
         return state.domain not in domains_for_exclude
 
     def filter_useless_units(state: State) -> bool:
+        """Filter out states with useless for us units of measurements."""
         units_for_exclude = [
             # Electric
             "W",

--- a/custom_components/thermal_comfort/config_flow.py
+++ b/custom_components/thermal_comfort/config_flow.py
@@ -28,7 +28,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def get_sensors_by_device_class(
-    _er: EntityRegistry,
+    _entity_registry_instance: EntityRegistry,
     _hass: HomeAssistant,
     device_class: str,
     include_not_in_registry: bool = False,
@@ -44,7 +44,8 @@ def get_sensors_by_device_class(
 
     if include_not_in_registry:
         result += list(
-            {e.entity_id for e in _hass.states.async_all()} - set(_er.entities)
+            {e.entity_id for e in _hass.states.async_all()}
+            - set(_entity_registry_instance.entities)
         )
     return result
 
@@ -79,12 +80,12 @@ def build_schema(
     :param step: for which step we should build schema
     :return: Configuration schema with default parameters
     """
-    er = entity_registry.async_get(hass)
-    h_sensors = get_sensors_by_device_class(
-        er, hass, DEVICE_CLASS_HUMIDITY, show_advanced
+    entity_registry_instance = entity_registry.async_get(hass)
+    humidity_sensors = get_sensors_by_device_class(
+        entity_registry_instance, hass, DEVICE_CLASS_HUMIDITY, show_advanced
     )
-    t_sensors = get_sensors_by_device_class(
-        er, hass, DEVICE_CLASS_TEMPERATURE, show_advanced
+    temperature_sensors = get_sensors_by_device_class(
+        entity_registry_instance, hass, DEVICE_CLASS_TEMPERATURE, show_advanced
     )
 
     schema = vol.Schema(
@@ -94,12 +95,16 @@ def build_schema(
             ): str,
             vol.Required(
                 CONF_TEMPERATURE_SENSOR,
-                default=get_value(config_entry, CONF_TEMPERATURE_SENSOR, t_sensors[0]),
-            ): vol.In(t_sensors),
+                default=get_value(
+                    config_entry, CONF_TEMPERATURE_SENSOR, temperature_sensors[0]
+                ),
+            ): vol.In(temperature_sensors),
             vol.Required(
                 CONF_HUMIDITY_SENSOR,
-                default=get_value(config_entry, CONF_HUMIDITY_SENSOR, h_sensors[0]),
-            ): vol.In(h_sensors),
+                default=get_value(
+                    config_entry, CONF_HUMIDITY_SENSOR, humidity_sensors[0]
+                ),
+            ): vol.In(humidity_sensors),
         },
     )
     if show_advanced:

--- a/custom_components/thermal_comfort/config_flow.py
+++ b/custom_components/thermal_comfort/config_flow.py
@@ -35,12 +35,12 @@ def get_sensors_by_device_class(
 ) -> list:
     """Get sensors of required class from entity registry."""
 
-    result = []
-    for d in _er.async_get_device_class_lookup(
-        {(Platform.SENSOR, device_class)}
-    ).values():
-        for e in d.values():
-            result.append(e)
+    result = [
+        entity.values()
+        for entity in _entity_registry_instance.async_get_device_class_lookup(
+            {(Platform.SENSOR, device_class)}
+        ).values()
+    ]
 
     if include_not_in_registry:
         result += list(

--- a/custom_components/thermal_comfort/config_flow.py
+++ b/custom_components/thermal_comfort/config_flow.py
@@ -41,7 +41,7 @@ def get_sensors_by_device_class(
         return not ((collected_device_class in _list) ^ should_be_in)
 
     def filter_for_device_class_sensor(state: State) -> bool:
-        """Filter states by Platform.SENSOR and SensorDeviceClass.TEMPERATURE."""
+        """Filter states by Platform.SENSOR and required device class."""
         return state.domain == Platform.SENSOR and filter_by_device_class(
             state, [device_class], should_be_in=True
         )

--- a/custom_components/thermal_comfort/config_flow.py
+++ b/custom_components/thermal_comfort/config_flow.py
@@ -44,8 +44,7 @@ def get_sensors_by_device_class(
 
     if include_not_in_registry:
         result += list(
-            {e.entity_id for e in _hass.states.async_all()}
-            - {e.entity_id for e in _er.entities}
+            {e.entity_id for e in _hass.states.async_all()} - {e for e in _er.entities}
         )
     return result
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -6,6 +6,7 @@ from homeassistant import config_entries, data_entry_flow
 from homeassistant.const import CONF_NAME
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
+import voluptuous as vol
 
 from custom_components.thermal_comfort.const import (
     CONF_HUMIDITY_SENSOR,
@@ -130,6 +131,7 @@ async def test_missed_sensors(hass, sensor, start_ha):
 
     no_sensor = dict(USER_INPUT)
     no_sensor[sensor] = "foo"
-    result = await _flow_configure(hass, result, no_sensor)
+    with pytest.raises(vol.error.MultipleInvalid):
+        result = await _flow_configure(hass, result, no_sensor)
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM


### PR DESCRIPTION
While configuration it is comfortable just to click at sensor.
Allow user doing this.

Not all sensors may be in device registry, but we can't check sensors out of registry. We should not limit advanced users in their choose (just because if root tries `rm -rf /`, it should be root problem, not OS), but should help ordinary users.

Alternative version of #105 