### PR TITLE
Add custom_icons option to the sensor platform

### DIFF
--- a/custom_components/thermal_comfort/__init__.py
+++ b/custom_components/thermal_comfort/__init__.py
@@ -27,7 +27,7 @@ from .const import (
     PLATFORMS,
     UPDATE_LISTENER,
 )
-from .sensor import SensorType
+from .sensor import CONF_CUSTOM_ICONS, SensorType
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -40,6 +40,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         CONF_TEMPERATURE_SENSOR: get_value(entry, CONF_TEMPERATURE_SENSOR),
         CONF_HUMIDITY_SENSOR: get_value(entry, CONF_HUMIDITY_SENSOR),
         CONF_POLL: get_value(entry, CONF_POLL),
+        CONF_CUSTOM_ICONS: get_value(entry, CONF_CUSTOM_ICONS),
     }
     if entry.unique_id is None:
         # We have no unique_id yet, let's use backup.

--- a/custom_components/thermal_comfort/config_flow.py
+++ b/custom_components/thermal_comfort/config_flow.py
@@ -16,7 +16,7 @@ from .const import (
     DEFAULT_NAME,
     DOMAIN,
 )
-from .sensor import DEFAULT_SENSOR_TYPES, SensorType
+from .sensor import CONF_CUSTOM_ICONS, DEFAULT_SENSOR_TYPES, SensorType
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -68,6 +68,10 @@ def build_schema(
             {
                 vol.Optional(
                     CONF_POLL, default=get_value(config_entry, CONF_POLL, False)
+                ): bool,
+                vol.Optional(
+                    CONF_CUSTOM_ICONS,
+                    default=get_value(config_entry, CONF_CUSTOM_ICONS, False),
                 ): bool,
             }
         )

--- a/custom_components/thermal_comfort/translations/en.json
+++ b/custom_components/thermal_comfort/translations/en.json
@@ -10,7 +10,8 @@
         "data": {
           "temperature_sensor": "Temperature sensor",
           "humidity_sensor": "Humidity sensor",
-          "poll": "Enable Polling"
+          "poll": "Enable Polling",
+          "custom_icons": "Use custom icons pack"
         }
       }
     }
@@ -31,6 +32,7 @@
           "temperature_sensor": "Temperature sensor",
           "humidity_sensor": "Humidity sensor",
           "poll": "Enable Polling",
+          "custom_icons": "Use custom icons pack",
           "absolute_humidity": "Enable Absolute humidity sensor",
           "dew_point": "Enable Dew point sensor",
           "frost_point": "Enable Frost point sensor",

--- a/tests/const.py
+++ b/tests/const.py
@@ -6,13 +6,14 @@ from custom_components.thermal_comfort.const import (
     CONF_POLL,
     CONF_TEMPERATURE_SENSOR,
 )
-from custom_components.thermal_comfort.sensor import SensorType
+from custom_components.thermal_comfort.sensor import CONF_CUSTOM_ICONS, SensorType
 
 USER_INPUT = {
     CONF_NAME: "test_thermal_comfort",
     CONF_TEMPERATURE_SENSOR: "sensor.test_temperature_sensor",
     CONF_HUMIDITY_SENSOR: "sensor.test_humidity_sensor",
     CONF_POLL: False,
+    CONF_CUSTOM_ICONS: False,
 }
 
 USER_NEW_INPUT = dict(USER_INPUT)


### PR DESCRIPTION
The custom_icons option which defaults to false allows to use the icons
from the thermal_comfort_icons pack as default icons when enabled.

https://github.com/rautesamtr/thermal_comfort_icons/

closes #101 