### PR TITLE
Disable config flow entities only once

### DIFF
--- a/custom_components/thermal_comfort/__init__.py
+++ b/custom_components/thermal_comfort/__init__.py
@@ -27,7 +27,7 @@ from .const import (
     PLATFORMS,
     UPDATE_LISTENER,
 )
-from .sensor import CONF_CUSTOM_ICONS, SensorType
+from .sensor import CONF_CUSTOM_ICONS, CONF_ENABLED_SENSORS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -42,12 +42,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         CONF_POLL: get_value(entry, CONF_POLL),
         CONF_CUSTOM_ICONS: get_value(entry, CONF_CUSTOM_ICONS),
     }
+    if get_value(entry, CONF_ENABLED_SENSORS):
+        hass.data[DOMAIN][entry.entry_id][CONF_ENABLED_SENSORS] = get_value(
+            entry, CONF_ENABLED_SENSORS
+        )
+        data = dict(entry.data)
+        data.pop(CONF_ENABLED_SENSORS)
+        hass.config_entries.async_update_entry(entry, data=data)
+
     if entry.unique_id is None:
         # We have no unique_id yet, let's use backup.
         hass.config_entries.async_update_entry(entry, unique_id=entry.entry_id)
-
-    for st in SensorType:
-        hass.data[DOMAIN][entry.entry_id][st] = get_value(entry, st)
 
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
     update_listener = entry.add_update_listener(async_update_options)

--- a/custom_components/thermal_comfort/translations/de.json
+++ b/custom_components/thermal_comfort/translations/de.json
@@ -33,15 +33,7 @@
           "humidity_sensor": "Feuchtigkeitssensor",
           "poll": "Polling verwenden",
           "custom_icons": "Benutzerdefinierte Icons verwenden",
-          "absolute_humidity": "Absolute-Feuchtesensor aktivieren",
-          "dew_point": "Taupunktsensor aktivieren",
-          "frost_point": "Frostpunksensor aktivieren",
-          "frost_risk": "Frostrisikosensor aktivieren",
-          "heat_index": "Hitzeindexsensor aktivieren",
-          "simmer_index": "Simmerindexsensor aktivieren",
-          "simmer_zone": "Simmerzonensensor aktivieren",
-          "thermal_perception": "Thermische-Wahrnemungssensor aktivieren",
-          "show_advanced_options": "Erweiterter Modus"
+          "enabled_sensors": "Aktivierte Sensoren"
         }
       }
     }

--- a/custom_components/thermal_comfort/translations/en.json
+++ b/custom_components/thermal_comfort/translations/en.json
@@ -33,15 +33,7 @@
           "humidity_sensor": "Humidity sensor",
           "poll": "Enable Polling",
           "custom_icons": "Use custom icons pack",
-          "absolute_humidity": "Enable Absolute humidity sensor",
-          "dew_point": "Enable Dew point sensor",
-          "frost_point": "Enable Frost point sensor",
-          "frost_risk": "Enable Frost risk sensor",
-          "heat_index": "Enable Heat index sensor",
-          "simmer_index": "Enable Simmer index sensor",
-          "simmer_zone": "Enable Simmer zone sensor",
-          "thermal_perception": "Enable Thermal perception sensor",
-          "show_advanced_options": "Advanced options"
+          "enabled_sensors": "Enabled sensors"
         }
       }
     }

--- a/tests/const.py
+++ b/tests/const.py
@@ -6,18 +6,21 @@ from custom_components.thermal_comfort.const import (
     CONF_POLL,
     CONF_TEMPERATURE_SENSOR,
 )
-from custom_components.thermal_comfort.sensor import CONF_CUSTOM_ICONS, SensorType
+from custom_components.thermal_comfort.sensor import (
+    CONF_CUSTOM_ICONS,
+    CONF_ENABLED_SENSORS,
+)
 
 USER_INPUT = {
-    CONF_NAME: "test_thermal_comfort",
+    CONF_NAME: "New name",
     CONF_TEMPERATURE_SENSOR: "sensor.test_temperature_sensor",
     CONF_HUMIDITY_SENSOR: "sensor.test_humidity_sensor",
     CONF_POLL: False,
     CONF_CUSTOM_ICONS: False,
 }
 
-USER_NEW_INPUT = dict(USER_INPUT)
-USER_NEW_INPUT[CONF_NAME] = "New name"
-
-for i in SensorType:
-    USER_INPUT[i] = True
+ADVANCED_USER_INPUT = {
+    **USER_INPUT,
+    CONF_NAME: "test_thermal_comfort",
+    CONF_ENABLED_SENSORS: [],
+}

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test integration_blueprint config flow."""
+
 import json
 from unittest.mock import MagicMock, patch
 
@@ -14,7 +15,7 @@ from custom_components.thermal_comfort.const import (
     DOMAIN,
 )
 
-from .const import USER_INPUT, USER_NEW_INPUT
+from .const import ADVANCED_USER_INPUT, USER_INPUT
 from .test_sensor import DEFAULT_TEST_SENSORS
 
 
@@ -38,7 +39,7 @@ async def _flow_init(hass, advanced_options=True):
     )
 
 
-async def _flow_configure(hass, r, _input=USER_INPUT):
+async def _flow_configure(hass, r, _input=ADVANCED_USER_INPUT):
     with patch(
         "homeassistant.helpers.entity_registry.EntityRegistry.async_get",
         return_value=MagicMock(unique_id="foo"),
@@ -62,8 +63,8 @@ async def test_successful_config_flow(hass, start_ha):
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
 
-    assert result["title"] == USER_INPUT[CONF_NAME]
-    assert result["data"] == USER_INPUT
+    assert result["title"] == ADVANCED_USER_INPUT[CONF_NAME]
+    assert result["data"] == ADVANCED_USER_INPUT
     assert result["result"]
 
 
@@ -84,7 +85,7 @@ async def test_failed_config_flow(hass, start_ha):
 async def test_options_flow(hass, start_ha):
     """Test flow for options changes."""
     # setup entry
-    entry = MockConfigEntry(domain=DOMAIN, data=USER_INPUT, entry_id="test")
+    entry = MockConfigEntry(domain=DOMAIN, data=ADVANCED_USER_INPUT, entry_id="test")
     entry.add_to_hass(hass)
 
     # Initialize an options flow for entry
@@ -99,7 +100,7 @@ async def test_options_flow(hass, start_ha):
     # Enter some data into the form
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        user_input=USER_NEW_INPUT,
+        user_input=USER_INPUT,
     )
 
     # Verify that the flow finishes
@@ -108,7 +109,7 @@ async def test_options_flow(hass, start_ha):
 
     # Verify that the options were updated
 
-    assert entry.options == USER_NEW_INPUT
+    assert entry.options == USER_INPUT
 
 
 async def test_config_flow_enabled():
@@ -129,7 +130,7 @@ async def test_missed_sensors(hass, sensor, start_ha):
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "user"
 
-    no_sensor = dict(USER_INPUT)
+    no_sensor = dict(ADVANCED_USER_INPUT)
     no_sensor[sensor] = "foo"
     with pytest.raises(vol.error.MultipleInvalid):
         result = await _flow_configure(hass, result, no_sensor)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -10,7 +10,7 @@ from custom_components.thermal_comfort import (
 )
 from custom_components.thermal_comfort.const import DOMAIN, PLATFORMS
 
-from .const import USER_INPUT
+from .const import ADVANCED_USER_INPUT
 
 
 async def test_setup_update_unload_entry(hass):
@@ -19,7 +19,7 @@ async def test_setup_update_unload_entry(hass):
     hass.config_entries.async_setup_platforms = MagicMock()
     with patch.object(hass.config_entries, "async_update_entry") as p:
         config_entry = MockConfigEntry(
-            domain=DOMAIN, data=USER_INPUT, entry_id="test", unique_id=None
+            domain=DOMAIN, data=ADVANCED_USER_INPUT, entry_id="test", unique_id=None
         )
         await hass.config_entries.async_add(config_entry)
         assert p.called
@@ -28,8 +28,12 @@ async def test_setup_update_unload_entry(hass):
     assert DOMAIN in hass.data and config_entry.entry_id in hass.data[DOMAIN]
 
     # check user input is in config
-    for i in USER_INPUT.keys():
-        assert hass.data[DOMAIN][config_entry.entry_id][i] == USER_INPUT[i]
+    for key in ADVANCED_USER_INPUT.keys():
+        if key in hass.data[DOMAIN][config_entry.entry_id]:
+            assert (
+                hass.data[DOMAIN][config_entry.entry_id][key]
+                == ADVANCED_USER_INPUT[key]
+            )
 
     hass.config_entries.async_setup_platforms.assert_called_with(
         config_entry, PLATFORMS

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -22,7 +22,7 @@ from custom_components.thermal_comfort.sensor import (
     id_generator,
 )
 
-from .const import USER_INPUT
+from .const import ADVANCED_USER_INPUT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -735,7 +735,7 @@ async def test_create_sensors(hass: HomeAssistant):
     er = entity_registry.async_get(hass)
 
     entry = MockConfigEntry(
-        domain=DOMAIN, data=USER_INPUT, entry_id="test", unique_id="uniqueid"
+        domain=DOMAIN, data=ADVANCED_USER_INPUT, entry_id="test", unique_id="uniqueid"
     )
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)


### PR DESCRIPTION
This changes the config flow entity setup to only set
entity_registry_enabled_default only once. After that it is managed by
the entity registry.

This also changes the selection of the enabled sensor types to a
multichoice. We loose translation for the sensor type itself, but we get
a cleaner and more usable interface for advanced users.

Tests where fixed and some variables renamed to make them more
descriptive.