### PR TITLE
Fix config flow crash on empty sensor lists 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.29.0
+    rev: v2.31.0
     hooks:
       - id: pyupgrade
         args: [--py38-plus]
   - repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.1.0
     hooks:
       - id: black
         args:
@@ -13,7 +13,7 @@ repos:
           - --quiet
         files: ^((custom_components|tests)/.+)?[^/]+\.py$
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.0.0
+    rev: v2.1.0
     hooks:
       - id: codespell
         args:
@@ -31,12 +31,12 @@ repos:
           - pyflakes==2.4.0
           - flake8-docstrings==1.6.0
           - pydocstyle==6.1.1
-          - flake8-comprehensions==3.7.0
-          - flake8-noqa==1.2.0
+          - flake8-comprehensions==3.8.0
+          - flake8-noqa==1.2.1
           - mccabe==0.6.1
         files: ^(custom_components|tests)/.+\.py$
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.0
+    rev: 1.7.2
     hooks:
       - id: bandit
         args:
@@ -45,11 +45,13 @@ repos:
           - --configfile=tests/bandit.yaml
         files: ^(custom_components|tests)/.+\.py$
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.0
+    rev: 5.10.1
     hooks:
       - id: isort
+        additional_dependencies:
+          - setuptools
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v4.1.0
     hooks:
       - id: check-executables-have-shebangs
         stages: [manual]
@@ -65,7 +67,7 @@ repos:
     hooks:
       - id: yamllint
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.2.1
+    rev: v2.5.1
     hooks:
       - id: prettier
         stages: [manual]

--- a/custom_components/thermal_comfort/config_flow.py
+++ b/custom_components/thermal_comfort/config_flow.py
@@ -350,6 +350,9 @@ def build_schema(
         entity_registry_instance, hass, SensorDeviceClass.TEMPERATURE, show_advanced
     )
 
+    if not temperature_sensors or not humidity_sensors:
+        return None
+
     schema = vol.Schema(
         {
             vol.Required(
@@ -458,13 +461,22 @@ class ThermalComfortConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     data=user_input,
                 )
 
+        schema = build_schema(
+            config_entry=None,
+            hass=self.hass,
+            show_advanced=self.show_advanced_options,
+        )
+
+        if schema is None:
+            if self.show_advanced_options:
+                reason = "no_sensors_advanced"
+            else:
+                reason = "no_sensors"
+            return self.async_abort(reason=reason)
+
         return self.async_show_form(
             step_id="user",
-            data_schema=build_schema(
-                config_entry=None,
-                hass=self.hass,
-                show_advanced=self.show_advanced_options,
-            ),
+            data_schema=schema,
             errors=errors,
         )
 

--- a/custom_components/thermal_comfort/translations/de.json
+++ b/custom_components/thermal_comfort/translations/de.json
@@ -18,7 +18,9 @@
   },
   "config": {
     "abort": {
-      "already_configured": "Diese Kombination aus Temperatursensor und Feuchtigkeitssensor wird bereits verwendet"
+      "already_configured": "Diese Kombination aus Temperatursensor und Feuchtigkeitssensor wird bereits verwendet",
+      "no_sensors": "Es wurden entweder keine Temperatursensoren oder Feuchtigkeitssensoren gefunden. Versuche es erneut im erweiterten Modus.",
+      "no_sensors_advanced": "Es wurden entweder keine Temperatursensoren oder Feuchtigkeitssensoren gefunden."
     },
     "error": {
       "temperature_not_found": "Temperatursensor konnte nicht gefunden werden",

--- a/custom_components/thermal_comfort/translations/en.json
+++ b/custom_components/thermal_comfort/translations/en.json
@@ -18,7 +18,9 @@
   },
   "config": {
     "abort": {
-      "already_configured": "This combination of temperature and humidity sensors is already configured"
+      "already_configured": "This combination of temperature and humidity sensors is already configured",
+      "no_sensors": "No temperature or humidity sensors found. Try again in advanced mode.",
+      "no_sensors_advanced": "No temperature or humidity sensors found."
     },
     "error": {
       "temperature_not_found": "Temperature sensor not found",


### PR DESCRIPTION
Abort config flow with error message if no input sensors are available.