### PR TITLE
Correctly handle sensor type from string

### DIFF
--- a/custom_components/thermal_comfort/sensor.py
+++ b/custom_components/thermal_comfort/sensor.py
@@ -91,28 +91,28 @@ class SensorType(StrEnum):
             return self.value.replace("_", "")
 
     @classmethod
-    def from_shortform(cls, shortform: str) -> "SensorType":
-        """Return the sensor type from the shortform."""
-        if "_" in shortform:
-            return shortform
-        elif shortform == "absolutehumidity":
+    def from_string(cls, string: str) -> "SensorType":
+        """Return the sensor type from string."""
+        if string in list(cls):
+            return cls(string)
+        elif string == "absolutehumidity":
             return cls.ABSOLUTE_HUMIDITY
-        elif shortform == "dewpoint":
+        elif string == "dewpoint":
             return cls.DEW_POINT
-        elif shortform == "frostpoint":
+        elif string == "frostpoint":
             return cls.FROST_POINT
-        elif shortform == "frostrisk":
+        elif string == "frostrisk":
             return cls.FROST_RISK
-        elif shortform == "heatindex":
+        elif string == "heatindex":
             return cls.HEAT_INDEX
-        elif shortform == "simmerindex":
+        elif string == "simmerindex":
             return cls.SIMMER_INDEX
-        elif shortform == "simmerzone":
+        elif string == "simmerzone":
             return cls.SIMMER_ZONE
-        elif shortform == "perception":
+        elif string == "perception":
             return cls.THERMAL_PERCEPTION
         else:
-            raise ValueError(f"Unknown sensor type: {shortform}")
+            raise ValueError(f"Unknown sensor type: {string}")
 
 
 SENSOR_TYPES = {
@@ -283,11 +283,11 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             SensorThermalComfort(
                 device=compute_device,
                 entity_description=SensorEntityDescription(
-                    **SENSOR_TYPES[SensorType.from_shortform(sensor_type)]
+                    **SENSOR_TYPES[SensorType.from_string(sensor_type)]
                 ),
                 icon_template=device_config.get(CONF_ICON_TEMPLATE),
                 entity_picture_template=device_config.get(CONF_ENTITY_PICTURE_TEMPLATE),
-                sensor_type=SensorType.from_shortform(sensor_type),
+                sensor_type=SensorType.from_string(sensor_type),
                 friendly_name=device_config.get(CONF_FRIENDLY_NAME),
                 custom_icons=device_config.get(CONF_CUSTOM_ICONS),
             )

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -748,16 +748,16 @@ async def test_create_sensors(hass: HomeAssistant):
 
 async def test_sensor_type_from_shortform() -> None:
     """Test if sensor types are correctly converted from shortform."""
-    assert SensorType.from_shortform("absolutehumidity") == SensorType.ABSOLUTE_HUMIDITY
-    assert SensorType.from_shortform("dewpoint") == SensorType.DEW_POINT
-    assert SensorType.from_shortform("frostpoint") == SensorType.FROST_POINT
-    assert SensorType.from_shortform("frostrisk") == SensorType.FROST_RISK
-    assert SensorType.from_shortform("heatindex") == SensorType.HEAT_INDEX
-    assert SensorType.from_shortform("simmerindex") == SensorType.SIMMER_INDEX
-    assert SensorType.from_shortform("simmerzone") == SensorType.SIMMER_ZONE
-    assert SensorType.from_shortform("perception") == SensorType.THERMAL_PERCEPTION
+    assert SensorType.from_string("absolutehumidity") == SensorType.ABSOLUTE_HUMIDITY
+    assert SensorType.from_string("dewpoint") == SensorType.DEW_POINT
+    assert SensorType.from_string("frostpoint") == SensorType.FROST_POINT
+    assert SensorType.from_string("frostrisk") == SensorType.FROST_RISK
+    assert SensorType.from_string("heatindex") == SensorType.HEAT_INDEX
+    assert SensorType.from_string("simmerindex") == SensorType.SIMMER_INDEX
+    assert SensorType.from_string("simmerzone") == SensorType.SIMMER_ZONE
+    assert SensorType.from_string("perception") == SensorType.THERMAL_PERCEPTION
     with pytest.raises(ValueError) as error:
-        SensorType.from_shortform("unknown")
+        SensorType.from_string("unknown")
     assert "Unknown sensor type: unknown" in str(error.value)
 
 
@@ -775,7 +775,8 @@ async def test_sensor_type_from_shortform() -> None:
                                 "temperature_sensor": "sensor.test_temperature_sensor",
                                 "humidity_sensor": "sensor.test_humidity_sensor",
                                 "sensor_types": [
-                                    SensorType.THERMAL_PERCEPTION.to_shortform()
+                                    SensorType.THERMAL_PERCEPTION.to_shortform(),
+                                    SensorType.ABSOLUTE_HUMIDITY,
                                 ],
                             },
                         },
@@ -791,7 +792,10 @@ async def test_sensor_type_from_shortform() -> None:
                         "name": "test_thermal_comfort",
                         "temperature_sensor": "sensor.test_temperature_sensor",
                         "humidity_sensor": "sensor.test_humidity_sensor",
-                        "sensor_types": [SensorType.THERMAL_PERCEPTION.to_shortform()],
+                        "sensor_types": [
+                            SensorType.THERMAL_PERCEPTION.to_shortform(),
+                            SensorType.ABSOLUTE_HUMIDITY,
+                        ],
                     },
                 },
             },
@@ -800,7 +804,7 @@ async def test_sensor_type_from_shortform() -> None:
 )
 async def test_sensor_type_names(hass: HomeAssistant, start_ha: Callable) -> None:
     """Test if sensor types shortform can be used."""
-    assert len(hass.states.async_all(PLATFORM_DOMAIN)) == 1
+    assert len(hass.states.async_all(PLATFORM_DOMAIN)) == 2
     assert (
         get_sensor(hass, SensorType.THERMAL_PERCEPTION).entity_id
         == f"{PLATFORM_DOMAIN}.test_thermal_comfort_{SensorType.THERMAL_PERCEPTION.to_shortform()}"


### PR DESCRIPTION
Instead of just returning a string if sensor_type is not a shortform
but correct sensor name return a SensorType as expected.

Add corresponding test case.

fixes #115 