### PR TITLE
Defaults for scan interval

### DIFF
--- a/custom_components/thermal_comfort/config_flow.py
+++ b/custom_components/thermal_comfort/config_flow.py
@@ -23,6 +23,8 @@ from .sensor import (
     CONF_CUSTOM_ICONS,
     CONF_ENABLED_SENSORS,
     CONF_SCAN_INTERVAL,
+    POLL_DEFAULT,
+    SCAN_INTERVAL_DEFAULT,
     SensorType,
 )
 
@@ -381,11 +383,13 @@ def build_schema(
         schema = schema.extend(
             {
                 vol.Optional(
-                    CONF_POLL, default=get_value(config_entry, CONF_POLL, False)
+                    CONF_POLL, default=get_value(config_entry, CONF_POLL, POLL_DEFAULT)
                 ): bool,
                 vol.Optional(
                     CONF_SCAN_INTERVAL,
-                    default=get_value(config_entry, CONF_SCAN_INTERVAL, 30),
+                    default=get_value(
+                        config_entry, CONF_SCAN_INTERVAL, SCAN_INTERVAL_DEFAULT
+                    ),
                 ): vol.All(vol.Coerce(int), vol.Range(min=1)),
                 vol.Optional(
                     CONF_CUSTOM_ICONS,

--- a/custom_components/thermal_comfort/sensor.py
+++ b/custom_components/thermal_comfort/sensor.py
@@ -319,6 +319,12 @@ async def async_setup_entry(
     Called via async_setup_platforms(, SENSOR) from __init__.py
     """
     data = hass.data[DOMAIN][config_entry.entry_id]
+    if data.get(CONF_SCAN_INTERVAL) is None:
+        hass.data[DOMAIN][config_entry.entry_id][
+            CONF_SCAN_INTERVAL
+        ] = SCAN_INTERVAL_DEFAULT
+        data[CONF_SCAN_INTERVAL] = SCAN_INTERVAL_DEFAULT
+
     _LOGGER.debug(f"async_setup_entry: {data}")
     compute_device = DeviceThermalComfort(
         hass=hass,

--- a/custom_components/thermal_comfort/sensor.py
+++ b/custom_components/thermal_comfort/sensor.py
@@ -62,6 +62,10 @@ CONF_SENSOR_TYPES = "sensor_types"
 CONF_CUSTOM_ICONS = "custom_icons"
 CONF_SCAN_INTERVAL = "scan_interval"
 
+# Default values
+POLL_DEFAULT = False
+SCAN_INTERVAL_DEFAULT = 30
+
 
 class ThermalComfortDeviceClass(StrEnum):
     """State class for thermal comfort sensors."""
@@ -177,8 +181,10 @@ DEFAULT_SENSOR_TYPES = list(SENSOR_TYPES.keys())
 
 PLATFORM_OPTIONS_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_POLL, default=False): cv.boolean,
-        vol.Optional(CONF_SCAN_INTERVAL, default=timedelta(seconds=30)): cv.time_period,
+        vol.Optional(CONF_POLL, default=POLL_DEFAULT): cv.boolean,
+        vol.Optional(
+            CONF_SCAN_INTERVAL, default=timedelta(seconds=SCAN_INTERVAL_DEFAULT)
+        ): cv.time_period,
         vol.Optional(CONF_CUSTOM_ICONS, default=False): cv.boolean,
     }
 )
@@ -520,7 +526,7 @@ class DeviceThermalComfort:
 
         if self._should_poll:
             if scan_interval is None:
-                scan_interval = timedelta(seconds=30)
+                scan_interval = timedelta(seconds=SCAN_INTERVAL_DEFAULT)
             async_track_time_interval(
                 self.hass,
                 self.async_update_sensors,


### PR DESCRIPTION
Use defaults for scan_interval while `async_setup_entry`.

It prevent crashes like
```
2022-02-01 18:47:34 DEBUG (MainThread) [custom_components.thermal_comfort.sensor] async_setup_entry: {'name': 'Thermal Comfort livingroom', 'temperature_sensor': 'sensor.livingroomsensorsbed_bme280_temperature', 'humidity_sensor': 'sensor.livingroomsensorsbed_bme280_humidity', 'poll': False, 'scan_interval': None, 'custom_icons': None, 'update_listener': <function ConfigEntry.add_update_listener.<locals>.<lambda> at 0xaf1da0b8>}
2022-02-01 18:47:34 ERROR (MainThread) [homeassistant.components.sensor] Error while setting up thermal_comfort platform for sensor
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 249, in _async_setup_platform
    await asyncio.shield(task)
  File "/config/custom_components/thermal_comfort/sensor.py", line 328, in async_setup_entry
    scan_interval=timedelta(
TypeError: unsupported type for timedelta seconds component: NoneType

```