### PR TITLE
feat: add climate domain to useless list

### DIFF
--- a/custom_components/thermal_comfort/config_flow.py
+++ b/custom_components/thermal_comfort/config_flow.py
@@ -102,6 +102,7 @@ def get_sensors_by_device_class(
             Platform.BUTTON,
             Platform.CALENDAR,
             Platform.CAMERA,
+            Platform.CLIMATE,
             Platform.COVER,
             Platform.DEVICE_TRACKER,
             Platform.FAN,


### PR DESCRIPTION
We are probably will be able to use it in the future, but not now.
Part of #121 