### PR TITLE
ci: add archive to release

### DIFF
--- a/.github/workflows/add_archive_to_release.yml
+++ b/.github/workflows/add_archive_to_release.yml
@@ -1,0 +1,36 @@
+name: Publish archive
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Publish archive
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: "Set package name"
+      working-directory: ./custom_components
+      run:  echo "package=$(ls -F | grep \/$ | sed -n "s/\///g;1p")" >> $GITHUB_ENV
+
+    - name: "Set variables"
+      working-directory: ./custom_components
+      run: |
+        echo "archive=${{ env.package }}.zip" >> $GITHUB_ENV
+        echo "basedir=$(pwd)/${{ env.package }}" >> $GITHUB_ENV
+
+    - name: "Zip component dir"
+      working-directory: ./custom_components/${{ env.package }}
+      run: zip ${{ env.archive }} -r ./
+
+    - name: Upload binaries to release
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: ./custom_components/${{ env.package }}/${{ env.archive }}
+        asset_name: ${{ env.archive }}
+        tag: ${{ github.ref }}
+        overwrite: true

--- a/.github/workflows/add_archive_to_release.yml
+++ b/.github/workflows/add_archive_to_release.yml
@@ -1,5 +1,6 @@
 name: Publish archive
 
+# yamllint disable-line rule:truthy
 on:
   release:
     types: [published]
@@ -10,27 +11,27 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: "Set package name"
-      working-directory: ./custom_components
-      run:  echo "package=$(ls -F | grep \/$ | sed -n "s/\///g;1p")" >> $GITHUB_ENV
+      - name: "Set package name"
+        working-directory: ./custom_components
+        run: echo "package=$(ls -F | grep \/$ | sed -n "s/\///g;1p")" >> $GITHUB_ENV
 
-    - name: "Set variables"
-      working-directory: ./custom_components
-      run: |
-        echo "archive=${{ env.package }}.zip" >> $GITHUB_ENV
-        echo "basedir=$(pwd)/${{ env.package }}" >> $GITHUB_ENV
+      - name: "Set variables"
+        working-directory: ./custom_components
+        run: |
+          echo "archive=${{ env.package }}.zip" >> $GITHUB_ENV
+          echo "basedir=$(pwd)/${{ env.package }}" >> $GITHUB_ENV
 
-    - name: "Zip component dir"
-      working-directory: ./custom_components/${{ env.package }}
-      run: zip ${{ env.archive }} -r ./
+      - name: "Zip component dir"
+        working-directory: ./custom_components/${{ env.package }}
+        run: zip ${{ env.archive }} -r ./
 
-    - name: Upload binaries to release
-      uses: svenstaro/upload-release-action@v2
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: ./custom_components/${{ env.package }}/${{ env.archive }}
-        asset_name: ${{ env.archive }}
-        tag: ${{ github.ref }}
-        overwrite: true
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ./custom_components/${{ env.package }}/${{ env.archive }}
+          asset_name: ${{ env.archive }}
+          tag: ${{ github.ref }}
+          overwrite: true

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,6 @@
 {
   "name": "Thermal Comfort",
   "home-assistant": "2021.12.0",
-  "render_readme": true
+  "render_readme": true,
+  "filename": "thermal_comfort.zip"
 }


### PR DESCRIPTION
It will:
  * allow use badges like
![GitHub release (latest by date)](https://img.shields.io/github/downloads/dolezsa/thermal_comfort/latest/total)
  * show downloads counters at integration page in HACS;
  * simplify manual installation;