### PR TITLE
Yaml global options

### DIFF
--- a/custom_components/thermal_comfort/__init__.py
+++ b/custom_components/thermal_comfort/__init__.py
@@ -18,6 +18,7 @@ from homeassistant.helpers.reload import async_reload_integration_platforms
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import async_get_integration
 
+from .config import OPTIONS_SCHEMA
 from .config_flow import get_value
 from .const import DOMAIN, PLATFORMS, UPDATE_LISTENER
 from .sensor import (
@@ -122,6 +123,7 @@ async def _process_config(hass: HomeAssistant, hass_config: ConfigType) -> None:
                         DOMAIN,
                         {
                             "devices": conf_section[platform_domain],
+                            "options": OPTIONS_SCHEMA(conf_section),
                         },
                         hass_config,
                     )

--- a/custom_components/thermal_comfort/__init__.py
+++ b/custom_components/thermal_comfort/__init__.py
@@ -19,15 +19,15 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import async_get_integration
 
 from .config_flow import get_value
-from .const import (
+from .const import DOMAIN, PLATFORMS, UPDATE_LISTENER
+from .sensor import (
+    CONF_CUSTOM_ICONS,
+    CONF_ENABLED_SENSORS,
     CONF_HUMIDITY_SENSOR,
     CONF_POLL,
+    CONF_SCAN_INTERVAL,
     CONF_TEMPERATURE_SENSOR,
-    DOMAIN,
-    PLATFORMS,
-    UPDATE_LISTENER,
 )
-from .sensor import CONF_CUSTOM_ICONS, CONF_ENABLED_SENSORS, CONF_SCAN_INTERVAL
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/thermal_comfort/config.py
+++ b/custom_components/thermal_comfort/config.py
@@ -9,8 +9,14 @@ import voluptuous as vol
 
 from . import sensor as sensor_platform
 from .const import DOMAIN
+from .sensor import PLATFORM_OPTIONS_SCHEMA as SENSOR_OPTIONS_SCHEMA
 
 PACKAGE_MERGE_HINT = "list"
+
+OPTIONS_SCHEMA = vol.Schema({}).extend(
+    SENSOR_OPTIONS_SCHEMA.schema,
+    extra=vol.REMOVE_EXTRA,
+)
 
 CONFIG_SECTION_SCHEMA = vol.Schema(
     {
@@ -18,7 +24,7 @@ CONFIG_SECTION_SCHEMA = vol.Schema(
             cv.ensure_list, [sensor_platform.SENSOR_SCHEMA]
         ),
     }
-)
+).extend(OPTIONS_SCHEMA.schema)
 
 
 async def async_validate_config(hass: HomeAssistant, config: ConfigType) -> ConfigType:

--- a/custom_components/thermal_comfort/config_flow.py
+++ b/custom_components/thermal_comfort/config_flow.py
@@ -12,17 +12,14 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_registry import EntityRegistry
 import voluptuous as vol
 
-from .const import (
-    CONF_HUMIDITY_SENSOR,
-    CONF_POLL,
-    CONF_TEMPERATURE_SENSOR,
-    DEFAULT_NAME,
-    DOMAIN,
-)
+from .const import DEFAULT_NAME, DOMAIN
 from .sensor import (
     CONF_CUSTOM_ICONS,
     CONF_ENABLED_SENSORS,
+    CONF_HUMIDITY_SENSOR,
+    CONF_POLL,
     CONF_SCAN_INTERVAL,
+    CONF_TEMPERATURE_SENSOR,
     POLL_DEFAULT,
     SCAN_INTERVAL_DEFAULT,
     SensorType,

--- a/custom_components/thermal_comfort/sensor.py
+++ b/custom_components/thermal_comfort/sensor.py
@@ -181,14 +181,15 @@ PLATFORM_OPTIONS_SCHEMA = vol.Schema(
         vol.Optional(CONF_POLL): cv.boolean,
         vol.Optional(CONF_SCAN_INTERVAL): cv.time_period,
         vol.Optional(CONF_CUSTOM_ICONS): cv.boolean,
-    }
+        vol.Optional(CONF_SENSOR_TYPES): cv.ensure_list,
+    },
+    extra=vol.REMOVE_EXTRA,
 )
 
 LEGACY_SENSOR_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_TEMPERATURE_SENSOR): cv.entity_id,
         vol.Required(CONF_HUMIDITY_SENSOR): cv.entity_id,
-        vol.Optional(CONF_SENSOR_TYPES): cv.ensure_list,
         vol.Optional(CONF_ICON_TEMPLATE): cv.template,
         vol.Optional(CONF_ENTITY_PICTURE_TEMPLATE): cv.template,
         vol.Optional(CONF_FRIENDLY_NAME): cv.string,
@@ -269,12 +270,15 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             dict(device_config, **{CONF_NAME: device_name})
             for (device_name, device_config) in config[CONF_SENSORS].items()
         ]
+        options = {}
     else:
         devices = discovery_info["devices"]
+        options = discovery_info["options"]
 
     sensors = []
 
     for device_config in devices:
+        device_config = options | device_config
         compute_device = DeviceThermalComfort(
             hass=hass,
             name=device_config.get(CONF_NAME),

--- a/custom_components/thermal_comfort/sensor.py
+++ b/custom_components/thermal_comfort/sensor.py
@@ -45,13 +45,7 @@ from homeassistant.helpers.template import Template
 from homeassistant.loader import async_get_custom_components
 import voluptuous as vol
 
-from .const import (
-    CONF_HUMIDITY_SENSOR,
-    CONF_POLL,
-    CONF_TEMPERATURE_SENSOR,
-    DEFAULT_NAME,
-    DOMAIN,
-)
+from .const import DEFAULT_NAME, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -62,6 +56,9 @@ CONF_SENSOR_TYPES = "sensor_types"
 CONF_CUSTOM_ICONS = "custom_icons"
 CONF_SCAN_INTERVAL = "scan_interval"
 
+CONF_TEMPERATURE_SENSOR = "temperature_sensor"
+CONF_HUMIDITY_SENSOR = "humidity_sensor"
+CONF_POLL = "poll"
 # Default values
 POLL_DEFAULT = False
 SCAN_INTERVAL_DEFAULT = 30

--- a/custom_components/thermal_comfort/sensor.py
+++ b/custom_components/thermal_comfort/sensor.py
@@ -178,11 +178,9 @@ DEFAULT_SENSOR_TYPES = list(SENSOR_TYPES.keys())
 
 PLATFORM_OPTIONS_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_POLL, default=POLL_DEFAULT): cv.boolean,
-        vol.Optional(
-            CONF_SCAN_INTERVAL, default=timedelta(seconds=SCAN_INTERVAL_DEFAULT)
-        ): cv.time_period,
-        vol.Optional(CONF_CUSTOM_ICONS, default=False): cv.boolean,
+        vol.Optional(CONF_POLL): cv.boolean,
+        vol.Optional(CONF_SCAN_INTERVAL): cv.time_period,
+        vol.Optional(CONF_CUSTOM_ICONS): cv.boolean,
     }
 )
 
@@ -190,7 +188,7 @@ LEGACY_SENSOR_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_TEMPERATURE_SENSOR): cv.entity_id,
         vol.Required(CONF_HUMIDITY_SENSOR): cv.entity_id,
-        vol.Optional(CONF_SENSOR_TYPES, default=DEFAULT_SENSOR_TYPES): cv.ensure_list,
+        vol.Optional(CONF_SENSOR_TYPES): cv.ensure_list,
         vol.Optional(CONF_ICON_TEMPLATE): cv.template,
         vol.Optional(CONF_ENTITY_PICTURE_TEMPLATE): cv.template,
         vol.Optional(CONF_FRIENDLY_NAME): cv.string,
@@ -283,8 +281,10 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             unique_id=device_config.get(CONF_UNIQUE_ID),
             temperature_entity=device_config.get(CONF_TEMPERATURE_SENSOR),
             humidity_entity=device_config.get(CONF_HUMIDITY_SENSOR),
-            should_poll=device_config.get(CONF_POLL),
-            scan_interval=device_config.get(CONF_SCAN_INTERVAL),
+            should_poll=device_config.get(CONF_POLL, POLL_DEFAULT),
+            scan_interval=device_config.get(
+                CONF_SCAN_INTERVAL, timedelta(seconds=SCAN_INTERVAL_DEFAULT)
+            ),
         )
 
         sensors += [
@@ -297,9 +297,11 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
                 entity_picture_template=device_config.get(CONF_ENTITY_PICTURE_TEMPLATE),
                 sensor_type=SensorType.from_string(sensor_type),
                 friendly_name=device_config.get(CONF_FRIENDLY_NAME),
-                custom_icons=device_config.get(CONF_CUSTOM_ICONS),
+                custom_icons=device_config.get(CONF_CUSTOM_ICONS, False),
             )
-            for sensor_type in device_config.get(CONF_SENSOR_TYPES)
+            for sensor_type in device_config.get(
+                CONF_SENSOR_TYPES, DEFAULT_SENSOR_TYPES
+            )
         ]
 
     async_add_entities(sensors)
@@ -330,7 +332,9 @@ async def async_setup_entry(
         temperature_entity=data[CONF_TEMPERATURE_SENSOR],
         humidity_entity=data[CONF_HUMIDITY_SENSOR],
         should_poll=data[CONF_POLL],
-        scan_interval=timedelta(seconds=data[CONF_SCAN_INTERVAL]),
+        scan_interval=timedelta(
+            seconds=data.get(CONF_SCAN_INTERVAL, SCAN_INTERVAL_DEFAULT)
+        ),
     )
 
     entities: list[SensorThermalComfort] = [

--- a/documentation/yaml.md
+++ b/documentation/yaml.md
@@ -1,16 +1,17 @@
 # YAML Configuration
 
-To use, add the following to your `configuration.yaml` file:
+To use, add according to the following example to your `configuration.yaml` file:
 
 ```yaml
 thermal_comfort:
-  - sensor:
+  - custom_icons: true  # global option for the entry
+    sensor:
     - name: Living Room
       temperature_sensor: sensor.temperature_livingroom
       humidity_sensor: sensor.humidity_livingroom
+      custom_icons: false  # override entry option for sensor
     - name: Bathroom
       poll: true
-      custom_icons: true
       temperature_sensor: sensor.temperature_bathroom
       humidity_sensor: sensor.humidity_bathroom
       sensor_types:
@@ -21,27 +22,9 @@ thermal_comfort:
 …
 ```
 ### Sensor Configuration Variables
+
+#### Sensor Options
 <dl>
-  <dt><strong>temperature_sensor</strong> <code>string</code> <code>REQUIRED</code></dt>
-  <dd>ID of temperature sensor entity to be used for calculations.</dd>
-  <dt><strong>humidity_sensor</strong>  <code>string</code> <code>REQUIRED</code></dt>
-  <dd>ID of humidity sensor entity to be used for calculations..</dd>
-  <dt><strong>icon_template</strong> <code>template</code> <code>(optional)</code></dt>
-  <dd>Defines a template for the icon of the sensor.</dd>
-  <dt><strong>entity_picture_template</strong> <code>template</code> <code>(optional)</code></dt>
-  <dd>Defines a template for the entity picture of the sensor.</dd>
-  <dt><strong>unique_id</strong> <code>string</code> <code>(optional)</code></dt>
-  <dd>
-    An ID that uniquely identifies the sensors. Set this to a unique value to
-    allow customization through the UI.
-    <p> Make sure this is a unique value. Home assistant uses this internally and you
-    will not see it in the frontend.
-    A good tool to get a unique value is the `uuidgen` command line tool or your can
-    use a <a href="https://www.uuidgenerator.net/">online uuid generator</a></p>
-    Internally we add the sensor type name to the unique id you set for each sensor.
-    e.g. with a unique id of `0ee4d8a7-c610-4afa-855d-0b2c2c265e11` for a absolute humidity
-    sensor you would get `0ee4d8a7-c610-4afa-855d-0b2c2c265e11absolute_humidity`.
-  </dd>
   <dt><strong>sensor_types</strong> <code>list</code> <code>(optional)</code></dt>
   <dd>
     A list of sensors to create. If omitted all will be created.
@@ -64,5 +47,34 @@ thermal_comfort:
   <dt><strong>custom_icons</strong> <code>boolean</code> <code>(optional, default: false)</code></dt>
   <dd>Set to true if you have the <a href="https://github.com/dolezsa/thermal_comfort/blob/master/README.md#custom-icons">custom icon pack</a>
     installed and want to use it as default icons for the sensors.
+  </dd>
+</dl>
+
+#### Sensor Configuration
+<dl>
+  <dt><strong>name</strong> <code>string</code> <code>(optional)</code></dt>
+  <dd>
+    Name of the sensor will be used both for the friendly name and entity id
+    combined with the sensor type. e.g. Kitchen would get your
+    `sensor.kitchen_absolutehumidity` and Kichten Absolute Humidity.</dd>
+  <dt><strong>temperature_sensor</strong> <code>string</code> <code>REQUIRED</code></dt>
+  <dd>ID of temperature sensor entity to be used for calculations.</dd>
+  <dt><strong>humidity_sensor</strong>  <code>string</code> <code>REQUIRED</code></dt>
+  <dd>ID of humidity sensor entity to be used for calculations..</dd>
+  <dt><strong>icon_template</strong> <code>template</code> <code>(optional)</code></dt>
+  <dd>Defines a template for the icon of the sensor.</dd>
+  <dt><strong>entity_picture_template</strong> <code>template</code> <code>(optional)</code></dt>
+  <dd>Defines a template for the entity picture of the sensor.</dd>
+  <dt><strong>unique_id</strong> <code>string</code> <code>(optional)</code></dt>
+  <dd>
+    An ID that uniquely identifies the sensors. Set this to a unique value to
+    allow customization through the UI.
+    <p> Make sure this is a unique value. Home assistant uses this internally and you
+    will not see it in the frontend.
+    A good tool to get a unique value is the `uuidgen` command line tool or your can
+    use a <a href="https://www.uuidgenerator.net/">online uuid generator</a></p>
+    Internally we add the sensor type name to the unique id you set for each sensor.
+    e.g. with a unique id of `0ee4d8a7-c610-4afa-855d-0b2c2c265e11` for a absolute humidity
+    sensor you would get `0ee4d8a7-c610-4afa-855d-0b2c2c265e11absolute_humidity`.
   </dd>
 </dl>

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -15,6 +15,8 @@ from custom_components.thermal_comfort.const import DOMAIN
 from custom_components.thermal_comfort.sensor import (
     ATTR_FROST_RISK_LEVEL,
     ATTR_HUMIDITY,
+    CONF_CUSTOM_ICONS,
+    CONF_SENSOR_TYPES,
     DEFAULT_SENSOR_TYPES,
     SensorType,
     SimmerZone,
@@ -812,4 +814,45 @@ async def test_sensor_type_names(hass: HomeAssistant, start_ha: Callable) -> Non
     assert (
         SensorType.THERMAL_PERCEPTION.to_title()
         in get_sensor(hass, SensorType.THERMAL_PERCEPTION).name
+    )
+
+
+@pytest.mark.parametrize(
+    "domains, config",
+    [
+        (
+            [(DOMAIN, 1)],
+            {
+                DOMAIN: {
+                    CONF_SENSOR_TYPES: [
+                        SensorType.ABSOLUTE_HUMIDITY,
+                    ],
+                    CONF_CUSTOM_ICONS: True,
+                    PLATFORM_DOMAIN: [
+                        {
+                            "name": "test_thermal_comfort",
+                            "temperature_sensor": "sensor.test_temperature_sensor",
+                            "humidity_sensor": "sensor.test_humidity_sensor",
+                            "sensor_types": [
+                                SensorType.THERMAL_PERCEPTION,
+                                SensorType.ABSOLUTE_HUMIDITY,
+                            ],
+                        },
+                        {
+                            "name": "test_thermal_comfort2",
+                            "temperature_sensor": "sensor.test_temperature_sensor",
+                            "humidity_sensor": "sensor.test_humidity_sensor",
+                        },
+                    ],
+                },
+            },
+        ),
+    ],
+)
+async def test_global_options(hass: HomeAssistant, start_ha: Callable) -> None:
+    """Test if global options are correctly set."""
+    assert len(hass.states.async_all(PLATFORM_DOMAIN)) == 3
+    assert (
+        get_sensor(hass, SensorType.THERMAL_PERCEPTION).attributes["icon"]
+        == f"tc:{SensorType.THERMAL_PERCEPTION.replace('_', '-')}"
     )


### PR DESCRIPTION
This adds global options per thermal comfort platform entry. This
options are set for all entries but can be overridden per sensor entry.

Supported options are `poll`, `scan_interval`, `custom_icons`,
`sensor_types`.

e.g.
```yaml
thermal_comfort:
  - poll: true
    scan_interval: 5
    sensor:
      - name: Kitchen
        …
      - name: Garage
        poll: false
```