### PR TITLE
Migrate to async_forward_entry_setups

### DIFF
--- a/custom_components/thermal_comfort/__init__.py
+++ b/custom_components/thermal_comfort/__init__.py
@@ -56,7 +56,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # We have no unique_id yet, let's use backup.
         hass.config_entries.async_update_entry(entry, unique_id=entry.entry_id)
 
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     update_listener = entry.add_update_listener(async_update_options)
     hass.data[DOMAIN][entry.entry_id][UPDATE_LISTENER] = update_listener
     return True

--- a/custom_components/thermal_comfort/sensor.py
+++ b/custom_components/thermal_comfort/sensor.py
@@ -326,7 +326,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up entity configured via user interface.
 
-    Called via async_setup_platforms(, SENSOR) from __init__.py
+    Called via async_forward_entry_setups(, SENSOR) from __init__.py
     """
     data = hass.data[DOMAIN][config_entry.entry_id]
     if data.get(CONF_SCAN_INTERVAL) is None:

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,2 +1,2 @@
 # Strictly for tests
-pytest-homeassistant-custom-component>=0.8.12
+pytest-homeassistant-custom-component>=0.11.1

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,5 @@
 """Test setup process."""
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -16,7 +16,7 @@ from .const import ADVANCED_USER_INPUT
 async def test_setup_update_unload_entry(hass):
     """Test entry setup and unload."""
 
-    hass.config_entries.async_setup_platforms = MagicMock()
+    hass.config_entries.async_forward_entry_setups = AsyncMock()
     with patch.object(hass.config_entries, "async_update_entry") as p:
         config_entry = MockConfigEntry(
             domain=DOMAIN, data=ADVANCED_USER_INPUT, entry_id="test", unique_id=None
@@ -35,7 +35,7 @@ async def test_setup_update_unload_entry(hass):
                 == ADVANCED_USER_INPUT[key]
             )
 
-    hass.config_entries.async_setup_platforms.assert_called_with(
+    hass.config_entries.async_forward_entry_setups.assert_called_with(
         config_entry, PLATFORMS
     )
 


### PR DESCRIPTION
Use async_forward_entry_setups instead of async_setup_platforms.
See https://developers.home-assistant.io/blog/2022/07/08/config_entry_forwards/