### PR TITLE
Add moist air enthalpy sensor

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2019 dolezsa
+Moist Air Enthalpy (c) 2019-2020, Federico Tartarini
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Thermal Comfort provides the following calculated sensors for Home Assistant.
   <dd>
     Human perception of the simmer index.
   </dd>
+  <dt><strong>Moist Air Enthalpy</strong></dt>
+  <dd>
+    The enthalpy of moist air is the sum of the enthalpy of the dry air and the enthalpy of the water vapour. Enthalpy is the total energy of a thermodynamic system.
+  </dd>
 </dl>
 
 ![Custom Icons](https://raw.githubusercontent.com/dolezsa/thermal_comfort/master/screenshots/living_room.png)

--- a/documentation/yaml.md
+++ b/documentation/yaml.md
@@ -32,7 +32,7 @@ thermal_comfort:
     <code>heat_index</code>, <code>dew_point</code>,
     <code>thermal_perception</code>, <code>frost_point</code>,
     <code>frost_risk</code>, <code>simmer_index</code>,
-    <code>simmer_zone</code>
+    <code>simmer_zone</code>, <code>moist_air_enthalpy</code>
   </dd>
   <dt><strong>poll</strong> <code>boolean</code> <code>(optional, default: false)</code></dt>
   <dd>

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -366,6 +366,19 @@ async def test_simmer_zone(hass, start_ha):
     )
 
 
+@pytest.mark.parametrize(*DEFAULT_TEST_SENSORS)
+async def test_moist_air_enthalpy(hass, start_ha):
+    """Test if moist air enthalpy is calculated correctly."""
+    assert get_sensor(hass, SensorType.MOIST_AIR_ENTHALPY) is not None
+    assert get_sensor(hass, SensorType.MOIST_AIR_ENTHALPY).state == "50.26"
+
+    hass.states.async_set("sensor.test_temperature_sensor", "20.77")
+    hass.states.async_set("sensor.test_humidity_sensor", "60.82")
+    await hass.async_block_till_done()
+    assert get_sensor(hass, SensorType.MOIST_AIR_ENTHALPY) is not None
+    assert get_sensor(hass, SensorType.MOIST_AIR_ENTHALPY).state == "44.45"
+
+
 @pytest.mark.parametrize(
     "domains, config",
     [


### PR DESCRIPTION
Uses code ported from pythermalcomfort and so needs an additional
copyright line in the LICENSE file.