### PR TITLE
Use TemperatureConverter util from core

### DIFF
--- a/custom_components/thermal_comfort/sensor.py
+++ b/custom_components/thermal_comfort/sensor.py
@@ -7,7 +7,6 @@ import logging
 import math
 from typing import Any
 
-from homeassistant import util
 from homeassistant.backports.enum import StrEnum
 from homeassistant.components.sensor import (
     PLATFORM_SCHEMA,
@@ -42,6 +41,8 @@ from homeassistant.helpers.event import (
 )
 from homeassistant.helpers.template import Template
 from homeassistant.loader import async_get_custom_components
+from homeassistant.util import convert
+from homeassistant.util.unit_conversion import TemperatureConverter
 import voluptuous as vol
 
 from .const import DEFAULT_NAME, DOMAIN
@@ -648,11 +649,11 @@ class DeviceThermalComfort:
     async def _new_temperature_state(self, state):
         if _is_valid_state(state):
             unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
-            temp = util.convert(state.state, float)
+            temp = convert(state.state, float)
             self.extra_state_attributes[ATTR_TEMPERATURE] = temp
             # convert to celsius if necessary
             if unit == TEMP_FAHRENHEIT:
-                temp = util.temperature.fahrenheit_to_celsius(temp)
+                temp = TemperatureConverter.convert(temp, TEMP_FAHRENHEIT, TEMP_CELSIUS)
             self._temperature = temp
             await self.async_update()
 
@@ -683,7 +684,9 @@ class DeviceThermalComfort:
     @compute_once_lock(SensorType.HEAT_INDEX)
     async def heat_index(self) -> float:
         """Heat Index <http://www.wpc.ncep.noaa.gov/html/heatindex_equation.shtml>."""
-        fahrenheit = util.temperature.celsius_to_fahrenheit(self._temperature)
+        fahrenheit = TemperatureConverter.convert(
+            self._temperature, TEMP_CELSIUS, TEMP_FAHRENHEIT
+        )
         hi = 0.5 * (
             fahrenheit + 61.0 + ((fahrenheit - 68.0) * 1.2) + (self._humidity * 0.094)
         )
@@ -705,7 +708,7 @@ class DeviceThermalComfort:
         elif self._humidity > 85 and fahrenheit >= 80 and fahrenheit <= 87:
             hi = hi + ((self._humidity - 85) * 0.1) * ((87 - fahrenheit) * 0.2)
 
-        return round(util.temperature.fahrenheit_to_celsius(hi), 2)
+        return round(TemperatureConverter.convert(hi, TEMP_FAHRENHEIT, TEMP_CELSIUS), 2)
 
     @compute_once_lock(SensorType.HUMIDEX)
     async def humidex(self) -> int:
@@ -867,7 +870,9 @@ class DeviceThermalComfort:
     @compute_once_lock(SensorType.SIMMER_INDEX)
     async def simmer_index(self) -> float:
         """<https://www.vcalc.com/wiki/rklarsen/Summer+Simmer+Index>."""
-        fahrenheit = util.temperature.celsius_to_fahrenheit(self._temperature)
+        fahrenheit = TemperatureConverter.convert(
+            self._temperature, TEMP_CELSIUS, TEMP_FAHRENHEIT
+        )
 
         si = (
             1.98
@@ -878,7 +883,7 @@ class DeviceThermalComfort:
         if fahrenheit < 70:
             si = fahrenheit
 
-        return round(util.temperature.fahrenheit_to_celsius(si), 2)
+        return round(TemperatureConverter.convert(si, TEMP_FAHRENHEIT, TEMP_CELSIUS), 2)
 
     @compute_once_lock(SensorType.SIMMER_ZONE)
     async def simmer_zone(self) -> (SimmerZone, float):

--- a/custom_components/thermal_comfort/sensor.py
+++ b/custom_components/thermal_comfort/sensor.py
@@ -652,8 +652,8 @@ class DeviceThermalComfort:
             temp = convert(state.state, float)
             self.extra_state_attributes[ATTR_TEMPERATURE] = temp
             # convert to celsius if necessary
-            if unit == TEMP_FAHRENHEIT:
-                temp = TemperatureConverter.convert(temp, TEMP_FAHRENHEIT, TEMP_CELSIUS)
+            if unit is not None:
+                temp = TemperatureConverter.convert(temp, unit, TEMP_CELSIUS)
             self._temperature = temp
             await self.async_update()
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "Thermal Comfort",
-  "homeassistant": "2021.12.0",
+  "homeassistant": "2022.10.0",
   "render_readme": true,
   "filename": "thermal_comfort.zip"
 }

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,2 +1,2 @@
 # Strictly for tests
-pytest-homeassistant-custom-component>=0.11.1
+pytest-homeassistant-custom-component>=0.12.8


### PR DESCRIPTION
Replace deprecated temperature utility with TemperatureConverter from util.unit_conversion which was introduced in home-assistant 2022.10. <https://developers.home-assistant.io/blog/2022/09/28/deprecate-conversion-utilities>

Co-authored-by: Emory Penney <treadstoneit@gmail.com>