### PR TITLE
Remove humidity deviceclass from absolute humidity

### DIFF
--- a/custom_components/thermal_comfort/sensor.py
+++ b/custom_components/thermal_comfort/sensor.py
@@ -119,7 +119,6 @@ SENSOR_TYPES = {
     SensorType.ABSOLUTE_HUMIDITY: {
         "key": SensorType.ABSOLUTE_HUMIDITY,
         "name": SensorType.ABSOLUTE_HUMIDITY.to_name(),
-        "device_class": SensorDeviceClass.HUMIDITY,
         "native_unit_of_measurement": "g/m³",
         "state_class": SensorStateClass.MEASUREMENT,
         "icon": "mdi:water",


### PR DESCRIPTION
This is needed since sensors humidity device class only supports % as unit and raises a warning when other units are used. This will be an error in 2023.6. See https://github.com/home-assistant/core/pull/84366