### PR TITLE
add inlang to make the contribution of translations easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Enable the custom icons options for your sensor in the
  [frontend](https://github.com/dolezsa/thermal_comfort/blob/master/documentation/config_flow.md#configuration-options)
  or in [yaml](https://github.com/dolezsa/thermal_comfort/blob/master/documentation/yaml.md#sensor-configuration-variables).
 
-### Localization 🌎🗺
+## Localization 🌎🗺
 Have a change you want to make with our translations? We have a frontend for updating localizations in our app easily, all you need is a GitHub account.
 
 [![translation badge](https://inlang.com/badge?url=github.com/dolezsa/thermal_comfort)](https://inlang.com/editor/github.com/dolezsa/thermal_comfort?ref=badge)

--- a/README.md
+++ b/README.md
@@ -78,3 +78,8 @@ Finally you need to restart home assistant before you can use it.
 Enable the custom icons options for your sensor in the
  [frontend](https://github.com/dolezsa/thermal_comfort/blob/master/documentation/config_flow.md#configuration-options)
  or in [yaml](https://github.com/dolezsa/thermal_comfort/blob/master/documentation/yaml.md#sensor-configuration-variables).
+
+### Localization 🌎🗺
+Have a change you want to make with our translations? We have a frontend for updating localizations in our app easily, all you need is a GitHub account.
+
+[![translation badge](https://inlang.com/badge?url=github.com/dolezsa/thermal_comfort)](https://inlang.com/editor/github.com/dolezsa/thermal_comfort?ref=badge)

--- a/README.md
+++ b/README.md
@@ -80,6 +80,6 @@ Enable the custom icons options for your sensor in the
  or in [yaml](https://github.com/dolezsa/thermal_comfort/blob/master/documentation/yaml.md#sensor-configuration-variables).
 
 ## Localization 🌎🗺
-Have a change you want to make with our translations? We have a frontend for updating localizations in our app easily, all you need is a GitHub account.
+Contribute translations directly with PRs or via inlang's web-editor.
 
 [![translation badge](https://inlang.com/badge?url=github.com/dolezsa/thermal_comfort)](https://inlang.com/editor/github.com/dolezsa/thermal_comfort?ref=badge)

--- a/inlang.config.js
+++ b/inlang.config.js
@@ -13,7 +13,7 @@ export async function defineConfig(env) {
   );
 
   const pluginConfig = {
-    pathPattern: "./custom_components/thermal_comfort.json/translations/{language}.json",
+    pathPattern: "./custom_components/thermal_comfort/translations/{language}.json",
   };
 
   return {

--- a/inlang.config.js
+++ b/inlang.config.js
@@ -1,0 +1,28 @@
+// @ts-check
+
+/**
+ * @type { import("@inlang/core/config").DefineConfig }
+ */
+export async function defineConfig(env) {
+  const plugin = await env.$import(
+    "https://cdn.jsdelivr.net/gh/samuelstroschein/inlang-plugin-json@1/dist/index.js"
+  );
+
+  const { standardLintRules } = await env.$import(
+    "https://cdn.jsdelivr.net/gh/inlang/standard-lint-rules@1/dist/index.js"
+  );
+
+  const pluginConfig = {
+    pathPattern: "./custom_components/thermal_comfort.json/translations/{language}.json",
+  };
+
+  return {
+    referenceLanguage: "en",
+    languages: await plugin.getLanguages({ ...env, pluginConfig }),
+    readResources: (args) => plugin.readResources({ ...args, ...env, pluginConfig }),
+    writeResources: (args) => plugin.writeResources({ ...args, ...env, pluginConfig }),
+    lint: {
+      rules: [standardLintRules()],
+    },
+  };
+}


### PR DESCRIPTION
Let me know what changes you request for merging this PR.

### Description
This pull request adds the possibility for contributors and translators to manage translations in a UI instead of files with no overhead for the maintainers.

To get a UI for translations contained in this repository, an [inlang.config.js](https://inlang.com/documentation/config) has been created at the root of the repository. Furthermore, the translation files have been cleaned and I added a little i18n docs on the read me. If you want this to be somewhere else please let me know.

### Preview
The changes of this PR and a live instance of the editor can be previewed with the following link https://inlang.com/editor/github.com/NilsJacobsen/thermal_comfort. Note: This link should be changed to point to dolezsa instead of NilsJacobsen after this PR has been merged.

### Badge
In the readme there is now a dynamic badge, which is going to show you the current status of the translations. It will work after the config is merged. You can see a demo badge rendered based on my fork.

[![translation badge](https://inlang.com/badge?url=github.com/NilsJacobsen/thermal_comfort)](https://inlang.com/editor/github.com/NilsJacobsen/thermal_comfort?ref=badge)

### Limitations
**Certain actions are slow**
Inlang is running entirely on git, giving tremendous CI/CD and contribution power to localization (and potentially other verticals -> [the next git](https://inlang.com/documentation/the-next-git)). That means that the whole thermal_comfort repo is cloned into the browser which makes certain actions like the initial load and pushing changes slow. Those limitations will be fixed with future releases and require no input from thermal_comfort.

![pika-1680686287719-1x](https://user-images.githubusercontent.com/58360188/232016041-ec0c3da3-94a9-4492-85dd-d8478c66d945.jpeg)

Preview the messages on https://inlang.com/editor/github.com/NilsJacobsen/thermal_comfort.