### PR TITLE
Support translated sensor names

### DIFF
--- a/custom_components/thermal_comfort/sensor.py
+++ b/custom_components/thermal_comfort/sensor.py
@@ -87,6 +87,7 @@ class SensorType(StrEnum):
 
     ABSOLUTE_HUMIDITY = "absolute_humidity"
     DEW_POINT = "dew_point"
+    DEW_POINT_PERCEPTION = "dew_point_perception"
     FROST_POINT = "frost_point"
     FROST_RISK = "frost_risk"
     HEAT_INDEX = "heat_index"
@@ -98,7 +99,6 @@ class SensorType(StrEnum):
     WINTER_SCHARLAU_PERCEPTION = "winter_scharlau_perception"
     SUMMER_SIMMER_INDEX = "summer_simmer_index"
     SUMMER_SIMMER_PERCEPTION = "summer_simmer_perception"
-    DEW_POINT_PERCEPTION = "dew_point_perception"
     THOMS_DISCOMFORT_PERCEPTION = "thoms_discomfort_perception"
 
     def to_name(self) -> str:
@@ -210,7 +210,6 @@ TC_ICONS = {
 SENSOR_TYPES = {
     SensorType.ABSOLUTE_HUMIDITY: {
         "key": SensorType.ABSOLUTE_HUMIDITY,
-        "name": SensorType.ABSOLUTE_HUMIDITY.to_name(),
         "suggested_display_precision": DISPLAY_PRECISION,
         "native_unit_of_measurement": "g/m³",
         "state_class": SensorStateClass.MEASUREMENT,
@@ -218,16 +217,20 @@ SENSOR_TYPES = {
     },
     SensorType.DEW_POINT: {
         "key": SensorType.DEW_POINT,
-        "name": SensorType.DEW_POINT.to_name(),
         "device_class": SensorDeviceClass.TEMPERATURE,
         "suggested_display_precision": DISPLAY_PRECISION,
         "native_unit_of_measurement": UnitOfTemperature.CELSIUS,
         "state_class": SensorStateClass.MEASUREMENT,
         "icon": "mdi:thermometer-water",
     },
+    SensorType.DEW_POINT_PERCEPTION: {
+        "key": SensorType.DEW_POINT_PERCEPTION,
+        "device_class": SensorDeviceClass.ENUM,
+        "options": list(map(str, DewPointPerception)),
+        "icon": "mdi:sun-thermometer",
+    },
     SensorType.FROST_POINT: {
         "key": SensorType.FROST_POINT,
-        "name": SensorType.FROST_POINT.to_name(),
         "device_class": SensorDeviceClass.TEMPERATURE,
         "suggested_display_precision": DISPLAY_PRECISION,
         "native_unit_of_measurement": UnitOfTemperature.CELSIUS,
@@ -236,15 +239,12 @@ SENSOR_TYPES = {
     },
     SensorType.FROST_RISK: {
         "key": SensorType.FROST_RISK,
-        "name": SensorType.FROST_RISK.to_name(),
         "device_class": SensorDeviceClass.ENUM,
         "options": list(map(str, FrostRisk)),
-        "translation_key": SensorType.FROST_RISK,
         "icon": "mdi:snowflake-alert",
     },
     SensorType.HEAT_INDEX: {
         "key": SensorType.HEAT_INDEX,
-        "name": SensorType.HEAT_INDEX.to_name(),
         "device_class": SensorDeviceClass.TEMPERATURE,
         "suggested_display_precision": DISPLAY_PRECISION,
         "native_unit_of_measurement": UnitOfTemperature.CELSIUS,
@@ -253,7 +253,6 @@ SENSOR_TYPES = {
     },
     SensorType.HUMIDEX: {
         "key": SensorType.HUMIDEX,
-        "name": SensorType.HUMIDEX.to_name(),
         "device_class": SensorDeviceClass.TEMPERATURE,
         "suggested_display_precision": DISPLAY_PRECISION,
         "native_unit_of_measurement": UnitOfTemperature.CELSIUS,
@@ -262,16 +261,12 @@ SENSOR_TYPES = {
     },
     SensorType.HUMIDEX_PERCEPTION: {
         "key": SensorType.HUMIDEX_PERCEPTION,
-        "name": SensorType.HUMIDEX_PERCEPTION.to_name(),
         "device_class": SensorDeviceClass.ENUM,
         "options": list(map(str, HumidexPerception)),
-        "translation_key": SensorType.HUMIDEX_PERCEPTION,
         "icon": "mdi:sun-thermometer",
     },
     SensorType.MOIST_AIR_ENTHALPY: {
         "key": SensorType.MOIST_AIR_ENTHALPY,
-        "name": SensorType.MOIST_AIR_ENTHALPY.to_name(),
-        "translation_key": SensorType.MOIST_AIR_ENTHALPY,
         "suggested_display_precision": DISPLAY_PRECISION,
         "native_unit_of_measurement": "kJ/kg",
         "state_class": SensorStateClass.MEASUREMENT,
@@ -279,31 +274,24 @@ SENSOR_TYPES = {
     },
     SensorType.RELATIVE_STRAIN_PERCEPTION: {
         "key": SensorType.RELATIVE_STRAIN_PERCEPTION,
-        "name": SensorType.RELATIVE_STRAIN_PERCEPTION.to_name(),
         "device_class": SensorDeviceClass.ENUM,
         "options": list(map(str, RelativeStrainPerception)),
-        "translation_key": SensorType.RELATIVE_STRAIN_PERCEPTION,
         "icon": "mdi:sun-thermometer",
     },
     SensorType.SUMMER_SCHARLAU_PERCEPTION: {
         "key": SensorType.SUMMER_SCHARLAU_PERCEPTION,
-        "name": SensorType.SUMMER_SCHARLAU_PERCEPTION.to_name(),
         "device_class": SensorDeviceClass.ENUM,
         "options": list(map(str, ScharlauPerception)),
-        "translation_key": "scharlau_perception",
         "icon": "mdi:sun-thermometer",
     },
     SensorType.WINTER_SCHARLAU_PERCEPTION: {
         "key": SensorType.WINTER_SCHARLAU_PERCEPTION,
-        "name": SensorType.WINTER_SCHARLAU_PERCEPTION.to_name(),
         "device_class": SensorDeviceClass.ENUM,
         "options": list(map(str, ScharlauPerception)),
-        "translation_key": "scharlau_perception",
         "icon": "mdi:snowflake-thermometer",
     },
     SensorType.SUMMER_SIMMER_INDEX: {
         "key": SensorType.SUMMER_SIMMER_INDEX,
-        "name": SensorType.SUMMER_SIMMER_INDEX.to_name(),
         "device_class": SensorDeviceClass.TEMPERATURE,
         "suggested_display_precision": DISPLAY_PRECISION,
         "native_unit_of_measurement": UnitOfTemperature.CELSIUS,
@@ -312,26 +300,14 @@ SENSOR_TYPES = {
     },
     SensorType.SUMMER_SIMMER_PERCEPTION: {
         "key": SensorType.SUMMER_SIMMER_PERCEPTION,
-        "name": SensorType.SUMMER_SIMMER_PERCEPTION.to_name(),
         "device_class": SensorDeviceClass.ENUM,
         "options": list(map(str, SummerSimmerPerception)),
-        "translation_key": SensorType.SUMMER_SIMMER_PERCEPTION,
-        "icon": "mdi:sun-thermometer",
-    },
-    SensorType.DEW_POINT_PERCEPTION: {
-        "key": SensorType.DEW_POINT_PERCEPTION,
-        "name": SensorType.DEW_POINT_PERCEPTION.to_name(),
-        "device_class": SensorDeviceClass.ENUM,
-        "options": list(map(str, DewPointPerception)),
-        "translation_key": SensorType.DEW_POINT_PERCEPTION,
         "icon": "mdi:sun-thermometer",
     },
     SensorType.THOMS_DISCOMFORT_PERCEPTION: {
         "key": SensorType.THOMS_DISCOMFORT_PERCEPTION,
-        "name": SensorType.THOMS_DISCOMFORT_PERCEPTION.to_name(),
         "device_class": SensorDeviceClass.ENUM,
         "options": list(map(str, ThomsDiscomfortPerception)),
-        "translation_key": SensorType.THOMS_DISCOMFORT_PERCEPTION,
         "icon": "mdi:sun-thermometer",
     },
 }
@@ -515,11 +491,14 @@ class SensorThermalComfort(SensorEntity):
         self._device = device
         self._sensor_type = sensor_type
         self.entity_description = entity_description
-        self.entity_description.has_entity_name = is_config_entry
+        self.entity_description.translation_key = sensor_type
+        self.entity_description.has_entity_name = True
         if not is_config_entry:
-            self.entity_description.name = (
-                f"{self._device.name} {self.entity_description.name}"
-            )
+            if self._device.name is not None:
+                self.entity_description.has_entity_name = False
+                self.entity_description.name = (
+                    f"{self._device.name} {self._sensor_type.to_name()}"
+                )
             if sensor_type in [SensorType.DEW_POINT_PERCEPTION, SensorType.SUMMER_SIMMER_INDEX, SensorType.SUMMER_SIMMER_PERCEPTION]:
                 registry = er.async_get(self._device.hass)
                 if sensor_type is SensorType.DEW_POINT_PERCEPTION:

--- a/custom_components/thermal_comfort/translations/ca.json
+++ b/custom_components/thermal_comfort/translations/ca.json
@@ -84,6 +84,24 @@
           "extreme_discomfort": "Molt incòmode"
         }
       },
+      "summer_scharlau_perception": {
+        "state": {
+          "outside_calculable_range": "Fora de l'interval calculable",
+          "comfortable": "Còmode",
+          "slightly_uncomfortable": "Una mica incòmode",
+          "moderatly_uncomfortable": "Bastant incòmode",
+          "highly_uncomfortable": "Molt incòmode"
+        }
+      },
+      "winter_scharlau_perception": {
+        "state": {
+          "outside_calculable_range": "Fora de l'interval calculable",
+          "comfortable": "Còmode",
+          "slightly_uncomfortable": "Una mica incòmode",
+          "moderatly_uncomfortable": "Bastant incòmode",
+          "highly_uncomfortable": "Molt incòmode"
+        }
+      },
       "summer_simmer_perception": {
         "state": {
           "cool": "Fred",
@@ -95,15 +113,6 @@
           "danger_of_heatstroke": "Perill de cop de calor",
           "extreme_danger_of_heatstroke": "Perill extrem de cop de calor",
           "circulatory_collapse_imminent": "Colapse circulatori imminent"
-        }
-      },
-      "scharlau_perception": {
-        "state": {
-          "outside_calculable_range": "Fora de l'interval calculable",
-          "comfortable": "Còmode",
-          "slightly_uncomfortable": "Una mica incòmode",
-          "moderatly_uncomfortable": "Bastant incòmode",
-          "highly_uncomfortable": "Molt incòmode"
         }
       },
       "thoms_discomfort_perception": {

--- a/custom_components/thermal_comfort/translations/da.json
+++ b/custom_components/thermal_comfort/translations/da.json
@@ -84,6 +84,24 @@
           "extreme_discomfort": "Ekstremt ubehag"
         }
       },
+      "summer_scharlau_perception": {
+        "state": {
+          "outside_calculable_range": "Uden for det beregnelige område",
+          "comfortable": "Komfortabel",
+          "slightly_uncomfortable": "Lidt ubehageligt",
+          "moderatly_uncomfortable": "Moderat ubehageligt",
+          "highly_uncomfortable": "Meget ubehageligt"
+        }
+      },
+      "winter_scharlau_perception": {
+        "state": {
+          "outside_calculable_range": "Uden for det beregnelige område",
+          "comfortable": "Komfortabel",
+          "slightly_uncomfortable": "Lidt ubehageligt",
+          "moderatly_uncomfortable": "Moderat ubehageligt",
+          "highly_uncomfortable": "Meget ubehageligt"
+        }
+      },
       "summer_simmer_perception": {
         "state": {
           "cool": "Køligt",
@@ -95,15 +113,6 @@
           "danger_of_heatstroke": "Fare for hedeslag",
           "extreme_danger_of_heatstroke": "Ekstrem fare for hedeslag",
           "circulatory_collapse_imminent": "Kredsløbskollaps nært forestående"
-        }
-      },
-      "scharlau_perception": {
-        "state": {
-          "outside_calculable_range": "Uden for det beregnelige område",
-          "comfortable": "Komfortabel",
-          "slightly_uncomfortable": "Lidt ubehageligt",
-          "moderatly_uncomfortable": "Moderat ubehageligt",
-          "highly_uncomfortable": "Meget ubehageligt"
         }
       },
       "thoms_discomfort_perception": {

--- a/custom_components/thermal_comfort/translations/de.json
+++ b/custom_components/thermal_comfort/translations/de.json
@@ -44,6 +44,9 @@
   },
   "entity": {
     "sensor": {
+      "absolute_humidity": {
+        "name": "Absolute Luftfeuchtigkeit"
+      },
       "frost_risk": {
         "state": {
           "no_risk": "Kein Risiko",
@@ -84,6 +87,24 @@
           "extreme_discomfort": "Extremes Unbehagen"
         }
       },
+      "summer_scharlau_perception": {
+        "state": {
+          "outside_calculable_range": "Außerhalb des berechenbaren Bereichs",
+          "comfortable": "Angenehm",
+          "slightly_uncomfortable": "Leicht unangenehm",
+          "moderatly_uncomfortable": "Unangenehm",
+          "highly_uncomfortable": "Sehr unangenehm"
+        }
+      },
+      "winter_scharlau_perception": {
+        "state": {
+          "outside_calculable_range": "Außerhalb des berechenbaren Bereichs",
+          "comfortable": "Angenehm",
+          "slightly_uncomfortable": "Leicht unangenehm",
+          "moderatly_uncomfortable": "Unangenehm",
+          "highly_uncomfortable": "Sehr unangenehm"
+        }
+      },
       "summer_simmer_perception": {
         "state": {
           "cool": "Kühl",
@@ -95,15 +116,6 @@
           "danger_of_heatstroke": "Hitzschlaggefahr",
           "extreme_danger_of_heatstroke": "Extreme Hitzschlaggefahr",
           "circulatory_collapse_imminent": "Drohender Kreislaufkollaps"
-        }
-      },
-      "scharlau_perception": {
-        "state": {
-          "outside_calculable_range": "Außerhalb des berechenbaren Bereichs",
-          "comfortable": "Angenehm",
-          "slightly_uncomfortable": "Leicht unangenehm",
-          "moderatly_uncomfortable": "Unangenehm",
-          "highly_uncomfortable": "Sehr unangenehm"
         }
       },
       "thoms_discomfort_perception": {

--- a/custom_components/thermal_comfort/translations/el.json
+++ b/custom_components/thermal_comfort/translations/el.json
@@ -84,6 +84,24 @@
           "extreme_discomfort": "Ακραία δυσφορία"
         }
       },
+      "summer_scharlau_perception": {
+        "state": {
+          "outside_calculable_range": "Εκτός του υπολογίσιμου εύρους",
+          "comfortable": "Άνετη",
+          "slightly_uncomfortable": "Ελαφρώς άβολη",
+          "moderatly_uncomfortable": "Μέτρια άβολη",
+          "highly_uncomfortable": "Ιδιαίτερα άβολη"
+        }
+      },
+      "winter_scharlau_perception": {
+        "state": {
+          "outside_calculable_range": "Εκτός του υπολογίσιμου εύρους",
+          "comfortable": "Άνετη",
+          "slightly_uncomfortable": "Ελαφρώς άβολη",
+          "moderatly_uncomfortable": "Μέτρια άβολη",
+          "highly_uncomfortable": "Ιδιαίτερα άβολη"
+        }
+      },
       "summer_simmer_perception": {
         "state": {
           "cool": "Δροσερή",
@@ -95,15 +113,6 @@
           "danger_of_heatstroke": "Κίνδυνος θερμοπληξίας",
           "extreme_danger_of_heatstroke": "Ακραίος κίνδυνος θερμοπληξίας",
           "circulatory_collapse_imminent": "Επικείμενη κυκλοφορική κατάρρευση"
-        }
-      },
-      "scharlau_perception": {
-        "state": {
-          "outside_calculable_range": "Εκτός του υπολογίσιμου εύρους",
-          "comfortable": "Άνετη",
-          "slightly_uncomfortable": "Ελαφρώς άβολη",
-          "moderatly_uncomfortable": "Μέτρια άβολη",
-          "highly_uncomfortable": "Ιδιαίτερα άβολη"
         }
       },
       "thoms_discomfort_perception": {

--- a/custom_components/thermal_comfort/translations/en.json
+++ b/custom_components/thermal_comfort/translations/en.json
@@ -44,15 +44,14 @@
   },
   "entity": {
     "sensor": {
-      "frost_risk": {
-        "state": {
-          "no_risk": "No risk",
-          "unlikely": "Unlikely",
-          "probable": "Probable",
-          "high": "High probability"
-        }
+      "absolute_humidity": {
+        "name": "Absolute humidity"
+      },
+      "dew_point": {
+        "name": "Dew point"
       },
       "dew_point_perception": {
+        "name": "Dew point perception",
         "state": {
           "dry": "A bit dry for some",
           "very_comfortable": "Very comfortable",
@@ -64,7 +63,26 @@
           "severely_high": "Severely high, even deadly for asthma related illnesses"
         }
       },
+      "frost_point": {
+        "name": "Frost point"
+      },
+      "frost_risk": {
+        "name": "Frost risk",
+        "state": {
+          "no_risk": "No risk",
+          "unlikely": "Unlikely",
+          "probable": "Probable",
+          "high": "High probability"
+        }
+      },
+      "heat_index": {
+        "name": "Heat index"
+      },
+      "humidex": {
+        "name": "Humidex"
+      },
       "humidex_perception": {
+        "name": "Humidex perception",
         "state": {
           "comfortable": "Comfortable",
           "noticable_discomfort": "Noticeable discomfort",
@@ -74,7 +92,11 @@
           "heat_stroke": "Heat stroke possible"
         }
       },
+      "moist_air_enthalpy": {
+        "name": "Moist air enthalpy"
+      },
       "relative_strain_perception": {
+        "name": "Relative strain perception",
         "state": {
           "outside_calculable_range": "Outside of the calculable range",
           "comfortable": "Comfortable",
@@ -84,7 +106,28 @@
           "extreme_discomfort": "Extreme discomfort"
         }
       },
+      "summer_scharlau_perception": {
+        "name": "Summer scharlau perception",
+        "state": {
+          "outside_calculable_range": "Outside of the calculable range",
+          "comfortable": "Comfortable",
+          "slightly_uncomfortable": "Slightly uncomfortable",
+          "moderatly_uncomfortable": "Moderatly uncomfortable",
+          "highly_uncomfortable": "Highly uncomfortable"
+        }
+      },
+      "winter_scharlau_perception": {
+        "name": "Winter scharlau perception",
+        "state": {
+          "outside_calculable_range": "Outside of the calculable range",
+          "comfortable": "Comfortable",
+          "slightly_uncomfortable": "Slightly uncomfortable",
+          "moderatly_uncomfortable": "Moderatly uncomfortable",
+          "highly_uncomfortable": "Highly uncomfortable"
+        }
+      },
       "summer_simmer_perception": {
+        "name": "Summer simmer perception",
         "state": {
           "cool": "Cool",
           "slightly_cool": "Slightly cool",
@@ -97,16 +140,8 @@
           "circulatory_collapse_imminent": "Circulatory collapse imminent"
         }
       },
-      "scharlau_perception": {
-        "state": {
-          "outside_calculable_range": "Outside of the calculable range",
-          "comfortable": "Comfortable",
-          "slightly_uncomfortable": "Slightly uncomfortable",
-          "moderatly_uncomfortable": "Moderatly uncomfortable",
-          "highly_uncomfortable": "Highly uncomfortable"
-        }
-      },
       "thoms_discomfort_perception": {
+        "name": "Thoms discomfort perception",
         "state": {
           "no_discomfort": "No discomfort",
           "less_then_half": "Less than half of the population feels discomfort",

--- a/custom_components/thermal_comfort/translations/es.json
+++ b/custom_components/thermal_comfort/translations/es.json
@@ -84,6 +84,24 @@
           "extreme_discomfort": "Muy incómodo"
         }
       },
+      "summer_scharlau_perception": {
+        "state": {
+          "outside_calculable_range": "Fuera del rango calculable",
+          "comfortable": "Cómodo",
+          "slightly_uncomfortable": "Un poco incómodo",
+          "moderatly_uncomfortable": "Bastante incómodo",
+          "highly_uncomfortable": "Muy incómodo"
+        }
+      },
+      "winter_scharlau_perception": {
+        "state": {
+          "outside_calculable_range": "Fuera del rango calculable",
+          "comfortable": "Cómodo",
+          "slightly_uncomfortable": "Un poco incómodo",
+          "moderatly_uncomfortable": "Bastante incómodo",
+          "highly_uncomfortable": "Muy incómodo"
+        }
+      },
       "summer_simmer_perception": {
         "state": {
           "cool": "Fresco",
@@ -95,15 +113,6 @@
           "danger_of_heatstroke": "Riesgo de golpe de calor",
           "extreme_danger_of_heatstroke": "Riesgo extremo de golpe de calor",
           "circulatory_collapse_imminent": "Colapso circulatorio inminente"
-        }
-      },
-      "scharlau_perception": {
-        "state": {
-          "outside_calculable_range": "Fuera del rango calculable",
-          "comfortable": "Cómodo",
-          "slightly_uncomfortable": "Un poco incómodo",
-          "moderatly_uncomfortable": "Bastante incómodo",
-          "highly_uncomfortable": "Muy incómodo"
         }
       },
       "thoms_discomfort_perception": {

--- a/custom_components/thermal_comfort/translations/fr.json
+++ b/custom_components/thermal_comfort/translations/fr.json
@@ -84,6 +84,24 @@
           "extreme_discomfort": "Inconfort extrême"
         }
       },
+      "summer_scharlau_perception": {
+        "state": {
+          "outside_calculable_range": "En dehors de la plage calculable",
+          "comfortable": "Confortable",
+          "slightly_uncomfortable": "Légèrement inconfortable",
+          "moderatly_uncomfortable": "Modérément inconfortable",
+          "highly_uncomfortable": "Très inconfortable"
+        }
+      },
+      "winter_scharlau_perception": {
+        "state": {
+          "outside_calculable_range": "En dehors de la plage calculable",
+          "comfortable": "Confortable",
+          "slightly_uncomfortable": "Légèrement inconfortable",
+          "moderatly_uncomfortable": "Modérément inconfortable",
+          "highly_uncomfortable": "Très inconfortable"
+        }
+      },
       "summer_simmer_perception": {
         "state": {
           "cool": "Froid",
@@ -95,15 +113,6 @@
           "danger_of_heatstroke": "Danger de coup de chaleur",
           "extreme_danger_of_heatstroke": "Danger extrême de coup de chaleur",
           "circulatory_collapse_imminent": "Arrêt cardiaque imminent"
-        }
-      },
-      "scharlau_perception": {
-        "state": {
-          "outside_calculable_range": "En dehors de la plage calculable",
-          "comfortable": "Confortable",
-          "slight_discomfort": "Légèrement inconfortable",
-          "moderatly_uncomfortable": "Modérément inconfortable",
-          "highly_uncomfortable": "Très inconfortable"
         }
       },
       "thoms_discomfort_perception": {

--- a/custom_components/thermal_comfort/translations/it.json
+++ b/custom_components/thermal_comfort/translations/it.json
@@ -84,6 +84,24 @@
           "extreme_discomfort": "Disagio estremo"
         }
       },
+      "summer_scharlau_perception": {
+        "state": {
+          "outside_calculable_range": "Fuori scala",
+          "comfortable": "Confortevole",
+          "slightly_uncomfortable": "Leggero disagio",
+          "moderatly_uncomfortable": "Moderato disagio",
+          "highly_uncomfortable": "Forte disagio"
+        }
+      },
+      "winter_scharlau_perception": {
+        "state": {
+          "outside_calculable_range": "Fuori scala",
+          "comfortable": "Confortevole",
+          "slightly_uncomfortable": "Leggero disagio",
+          "moderatly_uncomfortable": "Moderato disagio",
+          "highly_uncomfortable": "Forte disagio"
+        }
+      },
       "summer_simmer_perception": {
         "state": {
           "cool": "Freddo",
@@ -95,15 +113,6 @@
           "danger_of_heatstroke": "Pericolo colpo di calore",
           "extreme_danger_of_heatstroke": "Probabile colpo di calore",
           "circulatory_collapse_imminent": "Imminente colasso circolatorio"
-        }
-      },
-      "scharlau_perception": {
-        "state": {
-          "outside_calculable_range": "Fuori scala",
-          "comfortable": "Confortevole",
-          "slightly_uncomfortable": "Leggero disagio",
-          "moderatly_uncomfortable": "Moderato disagio",
-          "highly_uncomfortable": "Forte disagio"
         }
       },
       "thoms_discomfort_perception": {

--- a/custom_components/thermal_comfort/translations/nl.json
+++ b/custom_components/thermal_comfort/translations/nl.json
@@ -84,6 +84,24 @@
           "extreme_discomfort": "Extreem ongemakkelijk"
         }
       },
+      "summer_scharlau_perception": {
+        "state": {
+          "outside_calculable_range": "Buiten het berekenbare bereik",
+          "comfortable": "Gemakkelijk",
+          "slightly_uncomfortable": "Licht ongemakkelijk",
+          "moderatly_uncomfortable": "Matig ongemakkelijk",
+          "highly_uncomfortable": "Zeer ongemakkelijk"
+        }
+      },
+      "winter_scharlau_perception": {
+        "state": {
+          "outside_calculable_range": "Buiten het berekenbare bereik",
+          "comfortable": "Gemakkelijk",
+          "slightly_uncomfortable": "Licht ongemakkelijk",
+          "moderatly_uncomfortable": "Matig ongemakkelijk",
+          "highly_uncomfortable": "Zeer ongemakkelijk"
+        }
+      },
       "summer_simmer_perception": {
         "state": {
           "cool": "Koel",
@@ -95,15 +113,6 @@
           "danger_of_heatstroke": "Gevaar voor een zonnesteek",
           "extreme_danger_of_heatstroke": "Extreem gevaar voor een zonnesteek",
           "circulatory_collapse_imminent": "Instorting van de bloedsomloop dreigt"
-        }
-      },
-      "scharlau_perception": {
-        "state": {
-          "outside_calculable_range": "Buiten het berekenbare bereik",
-          "comfortable": "Gemakkelijk",
-          "slightly_uncomfortable": "Licht ongemakkelijk",
-          "moderatly_uncomfortable": "Matig ongemakkelijk",
-          "highly_uncomfortable": "Zeer ongemakkelijk"
         }
       },
       "thoms_discomfort_perception": {

--- a/custom_components/thermal_comfort/translations/pl.json
+++ b/custom_components/thermal_comfort/translations/pl.json
@@ -84,6 +84,24 @@
           "extreme_discomfort": "Ekstremalny dyskomfort"
         }
       },
+      "summer_scharlau_perception": {
+        "state": {
+          "outside_calculable_range": "Poza obliczalnym zakresem",
+          "comfortable": "Komfortowo",
+          "slightly_uncomfortable": "Lekki dyskomfort",
+          "moderatly_uncomfortable": "Dyskomfort",
+          "highly_uncomfortable": "Wysoki dyskomfort"
+        }
+      },
+      "winter_scharlau_perception": {
+        "state": {
+          "outside_calculable_range": "Poza obliczalnym zakresem",
+          "comfortable": "Komfortowo",
+          "slightly_uncomfortable": "Lekki dyskomfort",
+          "moderatly_uncomfortable": "Dyskomfort",
+          "highly_uncomfortable": "Wysoki dyskomfort"
+        }
+      },
       "summer_simmer_perception": {
         "state": {
           "cool": "Zimno",
@@ -95,15 +113,6 @@
           "danger_of_heatstroke": "Możliwy udar cieplny",
           "extreme_danger_of_heatstroke": "Wysokie niebezpieczeństwo udaru",
           "circulatory_collapse_imminent": "Zdecydowane problemy z krążeniem, zapaść"
-        }
-      },
-      "scharlau_perception": {
-        "state": {
-          "outside_calculable_range": "Poza obliczalnym zakresem",
-          "comfortable": "Komfortowo",
-          "slightly_uncomfortable": "Lekki dyskomfort",
-          "moderatly_uncomfortable": "Dyskomfort",
-          "highly_uncomfortable": "Wysoki dyskomfort"
         }
       },
       "thoms_discomfort_perception": {

--- a/custom_components/thermal_comfort/translations/pt.json
+++ b/custom_components/thermal_comfort/translations/pt.json
@@ -84,6 +84,24 @@
           "extreme_discomfort": "Extremo desconforto"
         }
       },
+      "summer_scharlau_perception": {
+        "state": {
+          "outside_calculable_range": "Fora do interválo de cálculo",
+          "comfortable": "Confortável",
+          "slightly_uncomfortable": "Ligeiramente desconfortável",
+          "moderatly_uncomfortable": "Desconforto moderado",
+          "highly_uncomfortable": "Muito desconfortável"
+        }
+      },
+      "winter_scharlau_perception": {
+        "state": {
+          "outside_calculable_range": "Fora do interválo de cálculo",
+          "comfortable": "Confortável",
+          "slightly_uncomfortable": "Ligeiramente desconfortável",
+          "moderatly_uncomfortable": "Desconforto moderado",
+          "highly_uncomfortable": "Muito desconfortável"
+        }
+      },
       "summer_simmer_perception": {
         "state": {
           "cool": "Frio",
@@ -95,15 +113,6 @@
           "danger_of_heatstroke": "Perigo de insolação",
           "extreme_danger_of_heatstroke": "Perigo extremo de insolação",
           "circulatory_collapse_imminent": "Colapso circulatório eminente"
-        }
-      },
-      "scharlau_perception": {
-        "state": {
-          "outside_calculable_range": "Fora do interválo de cálculo",
-          "comfortable": "Confortável",
-          "slightly_uncomfortable": "Ligeiramente desconfortável",
-          "moderatly_uncomfortable": "Desconforto moderado",
-          "highly_uncomfortable": "Muito desconfortável"
         }
       },
       "thoms_discomfort_perception": {

--- a/custom_components/thermal_comfort/translations/ro.json
+++ b/custom_components/thermal_comfort/translations/ro.json
@@ -84,6 +84,24 @@
           "extreme_discomfort": "Disconfort extrem"
         }
       },
+      "summer_scharlau_perception": {
+        "state": {
+          "outside_calculable_range": "În afara intervalului calculabil",
+          "comfortable": "Confortabil",
+          "slightly_uncomfortable": "Ușor inconfortabil",
+          "moderatly_uncomfortable": "Moderat inconfortabil",
+          "highly_uncomfortable": "Foarte inconfortabil"
+        }
+      },
+      "winter_scharlau_perception": {
+        "state": {
+          "outside_calculable_range": "În afara intervalului calculabil",
+          "comfortable": "Confortabil",
+          "slightly_uncomfortable": "Ușor inconfortabil",
+          "moderatly_uncomfortable": "Moderat inconfortabil",
+          "highly_uncomfortable": "Foarte inconfortabil"
+        }
+      },
       "summer_simmer_perception": {
         "state": {
           "cool": "Rece",
@@ -95,15 +113,6 @@
           "danger_of_heatstroke": "Pericol de insolație",
           "extreme_danger_of_heatstroke": "Pericol extrem de insolație",
           "circulatory_collapse_imminent": "Colapsul circulator iminent"
-        }
-      },
-      "scharlau_perception": {
-        "state": {
-          "outside_calculable_range": "În afara intervalului calculabil",
-          "comfortable": "Confortabil",
-          "slightly_uncomfortable": "Ușor inconfortabil",
-          "moderatly_uncomfortable": "Moderat inconfortabil",
-          "highly_uncomfortable": "Foarte inconfortabil"
         }
       },
       "thoms_discomfort_perception": {

--- a/custom_components/thermal_comfort/translations/ru.json
+++ b/custom_components/thermal_comfort/translations/ru.json
@@ -84,6 +84,24 @@
           "extreme_discomfort": "Черезвычайно некомфортно"
         }
       },
+      "summer_scharlau_perception": {
+        "state": {
+          "outside_calculable_range": "Значения датчиков вне допустимого диапазона",
+          "comfortable": "Комфортно",
+          "slightly_uncomfortable": "Слегка некомфортно",
+          "moderatly_uncomfortable": "Некомфортно",
+          "highly_uncomfortable": "Очень некомфортно"
+        }
+      },
+      "winter_scharlau_perception": {
+        "state": {
+          "outside_calculable_range": "Значения датчиков вне допустимого диапазона",
+          "comfortable": "Комфортно",
+          "slightly_uncomfortable": "Слегка некомфортно",
+          "moderatly_uncomfortable": "Некомфортно",
+          "highly_uncomfortable": "Очень некомфортно"
+        }
+      },
       "summer_simmer_perception": {
         "state": {
           "cool": "Холодно",
@@ -95,15 +113,6 @@
           "danger_of_heatstroke": "Риск теплового удара",
           "extreme_danger_of_heatstroke": "Серьёзный риск теплового удара",
           "circulatory_collapse_imminent": "Возможны сосудистые нарушения"
-        }
-      },
-      "scharlau_perception": {
-        "state": {
-          "outside_calculable_range": "Значения датчиков вне допустимого диапазона",
-          "comfortable": "Комфортно",
-          "slightly_uncomfortable": "Слегка некомфортно",
-          "moderatly_uncomfortable": "Некомфортно",
-          "highly_uncomfortable": "Очень некомфортно"
         }
       },
       "thoms_discomfort_perception": {

--- a/custom_components/thermal_comfort/translations/sk.json
+++ b/custom_components/thermal_comfort/translations/sk.json
@@ -84,6 +84,24 @@
           "extreme_discomfort": "Extrémny discomfort"
         }
       },
+      "summer_scharlau_perception": {
+        "state": {
+          "outside_calculable_range": "Mimo vypočítateľného rozsahu",
+          "comfortable": "Príjemne",
+          "slightly_uncomfortable": "Mierny diskomfort",
+          "moderatly_uncomfortable": "Stredne nepríjemné",
+          "highly_uncomfortable": "Veľmy nepríjemné"
+        }
+      },
+      "winter_scharlau_perception": {
+        "state": {
+          "outside_calculable_range": "Mimo vypočítateľného rozsahu",
+          "comfortable": "Príjemne",
+          "slightly_uncomfortable": "Mierny diskomfort",
+          "moderatly_uncomfortable": "Stredne nepríjemné",
+          "highly_uncomfortable": "Veľmy nepríjemné"
+        }
+      },
       "summer_simmer_perception": {
         "state": {
           "cool": "Chladno",
@@ -95,15 +113,6 @@
           "danger_of_heatstroke": "Nebezpečenstvo úpalu",
           "extreme_danger_of_heatstroke": "Extrémne nebezpečenstvo úpalu",
           "circulatory_collapse_imminent": "Hroziaci kolaps krvného obehu"
-        }
-      },
-      "scharlau_perception": {
-        "state": {
-          "outside_calculable_range": "Mimo vypočítateľného rozsahu",
-          "comfortable": "Príjemne",
-          "slightly_uncomfortable": "Mierny diskomfort",
-          "moderatly_uncomfortable": "Stredne nepríjemné",
-          "highly_uncomfortable": "Veľmy nepríjemné"
         }
       },
       "thoms_discomfort_perception": {

--- a/custom_components/thermal_comfort/translations/zh-Hans.json
+++ b/custom_components/thermal_comfort/translations/zh-Hans.json
@@ -84,6 +84,24 @@
           "extreme_discomfort": "极度不适"
         }
       },
+      "summer_scharlau_perception": {
+        "state": {
+          "outside_calculable_range": "超出可计算范围",
+          "comfortable": "舒适",
+          "slightly_uncomfortable": "稍微不舒服",
+          "moderatly_uncomfortable": "相当不舒服",
+          "highly_uncomfortable": "极不舒服"
+        }
+      },
+      "winter_scharlau_perception": {
+        "state": {
+          "outside_calculable_range": "超出可计算范围",
+          "comfortable": "舒适",
+          "slightly_uncomfortable": "稍微不舒服",
+          "moderatly_uncomfortable": "相当不舒服",
+          "highly_uncomfortable": "极不舒服"
+        }
+      },
       "summer_simmer_perception": {
         "state": {
           "cool": "凉爽",
@@ -95,15 +113,6 @@
           "danger_of_heatstroke": "有中暑的危险",
           "extreme_danger_of_heatstroke": "极度中暑的危险",
           "circulatory_collapse_imminent": "循环系统即将崩溃"
-        }
-      },
-      "scharlau_perception": {
-        "state": {
-          "outside_calculable_range": "超出可计算范围",
-          "comfortable": "舒适",
-          "slightly_uncomfortable": "稍微不舒服",
-          "moderatly_uncomfortable": "相当不舒服",
-          "highly_uncomfortable": "极不舒服"
         }
       },
       "thoms_discomfort_perception": {


### PR DESCRIPTION
https://developers.home-assistant.io/blog/2023/03/27/entity_name_translations

This PR adds support for translating sensor names. For this the `translation key` has been moved form the SENSOR_TYPES description map and is set in he SensorThermalComfort Class since every entity needs a `translation_key`. Translation works out of the box for config flow entities since we already implemented `has_entity_name` for them. It doesn't for YAML. With `has_entity_name` set to `True` and translations enabled we lose the name set for the device in YAML.

For now we only offer translations in YAML when the name isn't set.