### PR TITLE
Remove Platform.MAILBOX as its no longer supported

### DIFF
--- a/custom_components/thermal_comfort/config_flow.py
+++ b/custom_components/thermal_comfort/config_flow.py
@@ -111,7 +111,6 @@ def get_sensors_by_device_class(
             Platform.IMAGE_PROCESSING,
             Platform.LIGHT,
             Platform.LOCK,
-            Platform.MAILBOX,
             Platform.MEDIA_PLAYER,
             Platform.NOTIFY,
             Platform.REMOTE,


### PR DESCRIPTION
This causes an error when creating a new device with the extension with ha version 2024.09.0
Reference to the removal: https://github.com/home-assistant/core/pull/123741