### PR TITLE
Use zip file when installing in HACS

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -2,5 +2,6 @@
   "name": "Thermal Comfort",
   "homeassistant": "2023.12.0",
   "render_readme": true,
-  "filename": "thermal_comfort.zip"
+  "filename": "thermal_comfort.zip",
+  "zip_release": true
 }


### PR DESCRIPTION
Even though a zip file has been built in thermal_comfort for some time, it's not being used by HACS during installation because a keyword is missing in the hacs.json file.