### PR TITLE
Fix error in HA 2025.12 instantiating ThermalComfortOptionsFlow

### DIFF
--- a/custom_components/thermal_comfort/config_flow.py
+++ b/custom_components/thermal_comfort/config_flow.py
@@ -469,7 +469,7 @@ class ThermalComfortConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     @callback
     def async_get_options_flow(config_entry):
         """Get the options flow for this handler."""
-        return ThermalComfortOptionsFlow(config_entry)
+        return ThermalComfortOptionsFlow()
 
     async def async_step_user(self, user_input=None):
         """Handle a flow initialized by the user."""
@@ -518,10 +518,6 @@ class ThermalComfortConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
 class ThermalComfortOptionsFlow(config_entries.OptionsFlow):
     """Handle options."""
-
-    def __init__(self, config_entry):
-        """Initialize options flow."""
-        self.config_entry = config_entry
 
     async def async_step_init(self, user_input=None):
         """Manage the options."""


### PR DESCRIPTION
Due to https://developers.home-assistant.io/blog/2024/11/12/options-flow/, on HA 2025.12 the Thermal Comfort options flow fails to load with a 500 error (see https://github.com/dolezsa/thermal_comfort/issues/448).

The changes here fix the problem by implementing the recommendation in that post. The `config_entry` property is now provided automatically by `OptionsFlow`. Hence the existing code which set `self.config_entry` was both unecessary, and also incorrect (since assigning to a read only property caused an error).

With these changes I can open and use the options flow without error.